### PR TITLE
docs: initial project setup — spec, ADRs, Helm scaffold, governance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Go
+*.exe
+*.test
+*.out
+vendor/
+bin/
+
+# Node / Next.js
+node_modules/
+.next/
+out/
+dist/
+*.log
+
+# Helm
+*.tgz
+charts/*.tgz
+
+# Secrets
+*.env
+.env.*
+secrets/
+*.pem
+*.key
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build
+build/
+__pycache__/
+*.pyc

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+Aitra Meter follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+In short: be respectful, collaborative, and constructive. Harassment of any kind is not tolerated.
+
+## Reporting
+
+Report violations to the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md) or via the SODA Foundation escalation path described in [GOVERNANCE.md](GOVERNANCE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Aitra Meter
+
+Thank you for your interest in contributing.
+
+## Before you start
+
+Read the [Technical Specification](docs/spec/aitra-meter-spec-v1.0.md) and the [Architecture Decision Records](docs/adr/) to understand the design intent.
+
+## How to contribute
+
+1. Open an issue describing what you want to change and why.
+2. For spec or documentation changes, open a PR against the `docs/*` branch.
+3. For code changes, open a PR against `develop`.
+4. All PRs require at least one maintainer approval before merge.
+
+## Coding standards
+
+- Go: standard `gofmt` formatting, `golangci-lint` clean.
+- Python: `black` + `ruff`.
+- YAML: validated against schemas where available.
+
+## Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add idle power metric to measurement agent
+fix: correct proportional attribution for shared vLLM instances
+docs: update calibration tier definitions in spec
+```
+
+## Code of conduct
+
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,25 @@
+# Governance
+
+Aitra Meter is a SODA Foundation project hosted under the Linux Foundation ecosystem.
+
+## Decision making
+
+- **Minor changes** (documentation fixes, small bug fixes): lazy consensus — a PR with no objections after 48 hours from a maintainer can be merged.
+- **Major changes** (spec changes, architecture decisions, new dependencies): require at least two maintainer approvals and an open comment period of 5 business days.
+- **Breaking changes**: require a written Architecture Decision Record (ADR) in `docs/adr/` and a Phase milestone label.
+
+## Maintainers
+
+Current maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+**Adding a maintainer:** any existing maintainer may nominate a contributor who has made sustained, high-quality contributions. Approval requires a majority vote of existing maintainers.
+
+**Removing a maintainer:** a maintainer who has been inactive for 6 months may be moved to emeritus status by majority vote.
+
+## SODA Foundation escalation
+
+For unresolved disputes, escalate to the SODA Foundation Technical Steering Committee at [github.com/sodafoundation](https://github.com/sodafoundation).
+
+## Releases
+
+Releases follow semantic versioning (`vMAJOR.MINOR.PATCH`). Release tags are created from `main`. Release notes are required for every release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,49 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form.
+
+"Work" shall mean the work of authorship made available under the License.
+
+"Derivative Works" shall mean any work that is based on the Work.
+
+"Contribution" shall mean any work of authorship submitted to the Licensor for inclusion in the Work.
+
+"Contributor" shall mean Licensor and any Legal Entity on behalf of whom a Contribution has been received by the Licensor.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions: (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and (b) You must cause any modified files to carry prominent notices stating that You changed the files; and (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work; and (d) If the Work includes a "NOTICE" text file, You must include a readable copy of the attribution notices contained within such NOTICE file.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+8. Limitation of Liability. In no event and under no legal theory shall any Contributor be liable for damages arising from this License or out of the use or inability to use the Work.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work, You may offer acceptance of support, warranty, indemnity, or other liability obligations consistent with this License.
+
+END OF TERMS AND CONDITIONS
+
+Copyright 2026 Aitra Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Maintainers
+
+| Name | GitHub | Affiliation |
+|---|---|---|
+| Steven Phtan | @stevenphtan | Aitra |
+
+## Emeritus maintainers
+
+None yet.
+
+## Becoming a maintainer
+
+See [GOVERNANCE.md](GOVERNANCE.md) for the process.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,108 @@
-# aitra-meter
-Open-source Kubernetes-native AI inference efficiency measurement
+# Aitra Meter
+
+> Open-source Kubernetes-native AI inference efficiency measurement.
+
+**J/token** — joules per output token — measured continuously across every workload × model × hardware combination in your cluster.
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![SODA Foundation](https://img.shields.io/badge/SODA-Foundation-teal.svg)](https://sodafoundation.io)
+[![Project Status](https://img.shields.io/badge/status-pre--release-orange.svg)]()
+
+---
+
+## What it does
+
+Aitra Meter is the missing observability layer for AI inference. GPU utilisation is not inference efficiency. Throughput is not cost per token. Node-hour billing is not output economics. Aitra Meter connects hardware energy consumption to AI output volume at the token level — the primitive that was missing from the CNCF observability stack.
+
+It deploys entirely inside a single Kubernetes cluster. One Helm install. No infrastructure changes required.
+
+## The measurement frame
+
+Every J/token measurement is tagged with three dimensions:
+
+- **Workload** — chat · code · reasoning (from pod annotation `aitra.io/workload`)
+- **Model** — from vLLM metric label
+- **Hardware** — from Kubernetes node label
+
+## Quick start
+
+```bash
+helm repo add aitra https://charts.aitra.io
+helm install aitra-meter aitra/aitra-meter \
+  --namespace aitra-system --create-namespace \
+  --set cluster.name=my-cluster \
+  --set siteConfig.gridZone=SG \
+  --set siteConfig.electricityCostPerKwh=0.12
+```
+
+## What gets measured
+
+| Metric | Description |
+|---|---|
+| `aitra_j_per_token` | Joules per output token by workload × model × hardware |
+| `aitra_cluster_j_per_token` | Cluster-wide J/token (Σ energy ÷ Σ tokens) |
+| `aitra_co2_per_token_grams` | gCO₂ per token (J/token × grid intensity) |
+| `aitra_cost_per_million_tokens_usd` | $/M tokens (J/token × electricity cost) |
+| `aitra_idle_power_watts` | GPU power draw when no inference is running |
+| `aitra_namespace_energy_joules_total` | Total energy consumed per namespace |
+
+## Architecture
+
+```
+GPU nodes (DaemonSet · NVML · Zeus)
+vLLM pods (/metrics · token count)
+        │
+        ▼
+Aitra Meter — aggregation service
+(J/token · attribution · calibration · namespace resolution)
+        │
+   ┌────┴────┐
+   ▼         ▼
+Prometheus  ClickHouse
+   │         │
+   └────┬────┘
+        ▼
+Dashboard · Grafana · OTel · Lago
+```
+
+## CNCF integrations
+
+| Project | Role |
+|---|---|
+| Prometheus | ServiceMonitor auto-registers with kube-prometheus-stack |
+| OpenTelemetry | Collector sidecar for OTel-native stacks |
+| Envoy | Access log ingestion + ext_proc/ext_authz via Aitra Gateway |
+| OpenCost | Complementary — OpenCost = $/GPU-hr, Aitra Meter = $/M tokens |
+| KEDA | Scale inference workloads based on J/token and idle metrics |
+| Thanos | Phase 2 multi-cluster federation |
+
+## Dashboard views — Phase 1
+
+| View | Question answered |
+|---|---|
+| 1. J/token table | For each workload × model × hardware, what is the current J/token? |
+| 2a. Cluster over time | What is the cluster's energy consumption trend? |
+| 2b. By series | How is each combination trending individually? |
+| 3. Namespace chargeback | What does each namespace owe this billing period? |
+| 4. Idle consumption | How much energy is consumed while producing no tokens? |
+| 5. Carbon and cost | What is the carbon and energy cost per token? |
+
+## Documentation
+
+- [Technical Specification v1.0](docs/spec/aitra-meter-spec-v1.0.md)
+- [Project Blueprint](docs/blueprint/aitra-meter-blueprint.md)
+- [Architecture Decision Records](docs/adr/)
+- [Contributing](CONTRIBUTING.md)
+- [Governance](GOVERNANCE.md)
+
+## Project status
+
+Phase 1 (single-cluster) is in active development. See the [Technical Specification](docs/spec/aitra-meter-spec-v1.0.md) for full scope and acceptance criteria. Phase 2 (multi-cluster federation, Thanos, supercluster topology) is planned.
+
+## Governance
+
+Aitra Meter is a [SODA Foundation](https://sodafoundation.io) project. Research association: Tsinghua University / LF Research. Infrastructure: XFusion Singapore Open Lab.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/config/crd/measurementpolicy.yaml
+++ b/config/crd/measurementpolicy.yaml
@@ -1,0 +1,79 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: measurementpolicies.aitra.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+spec:
+  group: aitra.io
+  names:
+    kind: MeasurementPolicy
+    listKind: MeasurementPolicyList
+    plural: measurementpolicies
+    singular: measurementpolicy
+    shortNames:
+      - mp
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                scope:
+                  type: object
+                  properties:
+                    namespaces:
+                      type: array
+                      items:
+                        type: string
+                      description: Namespaces to measure. Empty = all namespaces.
+                attribution:
+                  type: object
+                  properties:
+                    defaultMethod:
+                      type: string
+                      enum: [direct, proportional]
+                      default: direct
+                    namespaceOverrides:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          namespace:
+                            type: string
+                          method:
+                            type: string
+                            enum: [direct, proportional]
+                calibration:
+                  type: object
+                  properties:
+                    preferredTier:
+                      type: string
+                      enum: [aitra_benchmark, reference, self_calibrated]
+                      default: aitra_benchmark
+                cv:
+                  type: object
+                  properties:
+                    threshold:
+                      type: number
+                      default: 0.03
+                    windowSize:
+                      type: integer
+                      default: 100
+                budget:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      namespace:
+                        type: string
+                      monthlyLimitUSD:
+                        type: number
+                      alertThresholdPct:
+                        type: integer

--- a/config/crd/siteconfig.yaml
+++ b/config/crd/siteconfig.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: siteconfigs.aitra.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+spec:
+  group: aitra.io
+  names:
+    kind: SiteConfig
+    listKind: SiteConfigList
+    plural: siteconfigs
+    singular: siteconfig
+    shortNames:
+      - sc
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                gridZone:
+                  type: string
+                  description: ElectricityMaps zone identifier
+                electricityCostPerKwh:
+                  type: number
+                  description: Electricity cost in USD per kWh
+                pue:
+                  type: number
+                  description: Power Usage Effectiveness — applied as multiplier in chargeback
+                  default: 1.0
+                carbonIntensityFallback:
+                  type: number
+                  description: gCO2/kWh — used when carbon API is unavailable
+                carbonSource:
+                  type: string
+                  enum: [electricitymaps, watttime, manual]
+                  default: manual

--- a/docs/adr/0001-kubernetes-native-daemonset.md
+++ b/docs/adr/0001-kubernetes-native-daemonset.md
@@ -1,0 +1,26 @@
+# ADR 0001: Kubernetes-native DaemonSet deployment
+
+## Status
+
+Accepted
+
+## Context
+
+Aitra Meter needs to measure GPU energy consumption at the node level. The measurement agent must run on every GPU-bearing node and have access to NVML (NVIDIA Management Library) for hardware-level power readings. Several deployment patterns were considered: sidecar injection into vLLM pods, a standalone node agent managed outside Kubernetes, and a DaemonSet with privileged access.
+
+## Decision
+
+Deploy the measurement agent as a Kubernetes DaemonSet with `hostPID: true` and `privileged: true`, scheduled only to nodes labeled `aitra.io/gpu=true`.
+
+## Rationale
+
+- DaemonSet is the standard Kubernetes pattern for per-node workloads. It is understood by platform teams and compatible with all cluster management tooling.
+- NVML requires hardware-level access that is only available with `hostPID` and privileged security context. There is no unprivileged alternative for direct GPU power readings.
+- Node affinity via `aitra.io/gpu=true` label prevents the agent from scheduling to non-GPU nodes, eliminating wasted pods.
+- Sidecar injection into vLLM pods was rejected because: (1) it couples Aitra Meter's lifecycle to the inference server's lifecycle, (2) it cannot aggregate measurements across multiple GPU devices per node, and (3) it requires modifying inference pod specs.
+
+## Consequences
+
+- Operators must label GPU-bearing nodes with `aitra.io/gpu=true` at cluster setup. This is a one-time administrative step, documented in the Helm chart README.
+- The DaemonSet requires privileged access, which some cluster policies restrict. For such clusters, operators must add a PodSecurityPolicy or equivalent exception for the `aitra-system` namespace.
+- Cross-node tensor parallelism (TP jobs spanning multiple Kubernetes clusters) cannot be measured by a per-node DaemonSet. This is deferred to Phase 2 (supercluster topology).

--- a/docs/adr/0002-zeus-measurement-engine.md
+++ b/docs/adr/0002-zeus-measurement-engine.md
@@ -1,0 +1,29 @@
+# ADR 0002: Zeus as the measurement engine
+
+## Status
+
+Accepted
+
+## Context
+
+Aitra Meter needs a reliable, production-tested library for GPU energy measurement. Options considered: build a custom NVML wrapper, use DCGM (NVIDIA Data Center GPU Manager), or use Zeus (ML.ENERGY / CMU).
+
+## Decision
+
+Use Zeus as the measurement engine for all GPU energy readings.
+
+## Rationale
+
+- Zeus is Apache 2.0 licensed and is a PyTorch ecosystem project (official PyTorch blog, May 2024). It has sustained academic and industry investment.
+- Zeus provides exactly the abstraction Aitra Meter needs: `begin_window()` / `end_window()` around a code block, returning joules consumed. This maps cleanly to vLLM request handler instrumentation.
+- Zeus expanded hardware support in May 2025 to include AMD GPUs (ROCm), CPU/DRAM, Apple Silicon, and NVIDIA Jetson — making Aitra Meter's measurement layer hardware-agnostic without additional code.
+- Zeus was selected as a 2024 Mozilla Technology Fund awardee, indicating sustained maintenance commitment.
+- Zeus includes `CarbonEmissionMonitor` and `EnergyCostMonitor` as first-class features, providing carbon and cost attribution without additional libraries.
+- DCGM was rejected because it is NVIDIA-proprietary and does not support AMD GPUs or non-NVIDIA hardware.
+- A custom NVML wrapper was rejected because Zeus already provides the exact functionality needed and maintaining a custom NVML layer is significant ongoing work.
+
+## Consequences
+
+- Aitra Meter takes a dependency on the Zeus Python package. Zeus is stable and actively maintained; version pinning in the Helm chart mitigates upgrade risk.
+- Zeus does not perform continuous batching attribution (it measures total energy for a window, not per-request). Aitra Meter must implement proportional attribution on top of Zeus for shared vLLM instances. See ADR 0003.
+- As vLLM versions evolve, Zeus-measured J/token benchmarks may go stale. Aitra Meter must detect vLLM version changes in metric labels and flag calibration baselines as potentially stale when a version change is detected.

--- a/docs/adr/0003-proportional-attribution.md
+++ b/docs/adr/0003-proportional-attribution.md
@@ -1,0 +1,31 @@
+# ADR 0003: Proportional attribution for shared vLLM instances
+
+## Status
+
+Accepted
+
+## Context
+
+vLLM uses continuous batching — multiple requests from different tenants execute in the same GPU forward pass within a single measurement window. Zeus measures total energy for the window. vLLM's Prometheus endpoint reports aggregate token counts, not per-request or per-namespace breakdowns. This creates an attribution problem: how do you allocate energy to individual namespaces when they share a GPU execution window?
+
+## Decision
+
+Support two attribution methods, declared per namespace in `MeasurementPolicy`:
+
+1. **Direct** — one vLLM instance per namespace. Energy and tokens are separately measured per instance. J/token per namespace is exact.
+2. **Proportional** — shared vLLM instance. Energy is allocated proportionally by token count: `namespace_energy = cluster_energy × (namespace_tokens / cluster_tokens)`.
+
+The attribution method used is stored in every measurement record and surfaced in every chargeback export. It is never hidden.
+
+## Rationale
+
+- Direct attribution (separate vLLM instances per namespace) is the recommended deployment pattern for enterprise clusters where accurate chargeback is required. It is already common practice. It eliminates attribution approximation entirely.
+- Proportional attribution by token count is the simplest auditable method for shared instances. It is reproducible, deterministic, and easy for operators to verify.
+- More accurate methods (separate prefill and decode windows, per-request energy estimation) were considered for Phase 1 but rejected on complexity grounds. Prefill is compute-bound and decode is memory-bandwidth-bound — the same token count has a different energy profile depending on prompt length vs output length. Correcting for this requires per-request prompt and output token counts, which vLLM's aggregate Prometheus metrics do not provide without additional instrumentation.
+- Aitra Gateway, when deployed, injects per-request token counts via Envoy access logs. When Gateway is present, the proportional approximation can be replaced with token-exact attribution. This is the upgrade path for operators who need higher accuracy.
+
+## Consequences
+
+- Operators running shared vLLM instances will see `attribution_method: proportional` in their chargeback reports. The approximation is documented and labeled — it is not silent.
+- Proportional attribution undercharges namespaces with long prompts and short outputs (high prefill fraction) and overcharges namespaces with short prompts and long outputs (high decode fraction). For most mixed workloads, this error is small.
+- Phase 2 will implement prefill/decode energy separation as a measurement improvement, which will allow more accurate proportional attribution without requiring Gateway.

--- a/docs/spec/aitra-meter-spec-v1.0.md
+++ b/docs/spec/aitra-meter-spec-v1.0.md
@@ -1,0 +1,497 @@
+---
+title: Aitra Meter — Technical Specification
+version: 1.0
+status: draft
+date: 2026-05-22
+authors: [Aitra contributors]
+soda-foundation: true
+---
+
+# Aitra Meter — Technical Specification
+
+**Version 1.0 · May 2026 · SODA Foundation**
+*Status: Draft for review*
+
+---
+
+## 1. Purpose and scope
+
+This document specifies the technical design of Aitra Meter Phase 1. It covers the measurement methodology, system architecture, component specifications, data model, attribution model, Kubernetes deployment, CNCF integrations, dashboard views, and acceptance criteria.
+
+Aitra Meter Phase 1 is scoped to a single Kubernetes cluster. Multi-cluster federation, supercluster topologies, and cross-site views are out of scope and are deferred to Phase 2.
+
+---
+
+## 2. Goals
+
+**G1** — Continuously measure J/token (joules per output token) for every active workload × model × hardware combination in a Kubernetes cluster.
+
+**G2** — Attribute energy consumption to Kubernetes namespaces using cluster metadata, without requiring changes to inference application code.
+
+**G3** — Derive carbon (gCO₂/token) and cost ($/M tokens) from measured J/token and configurable or API-sourced conversion factors.
+
+**G4** — Deploy entirely via a single Helm chart with no new infrastructure required beyond an existing Kubernetes cluster.
+
+**G5** — Integrate natively with the CNCF observability stack (Prometheus, OpenTelemetry, Grafana) already present in the cluster.
+
+**G6** — Surface measurements through six Phase 1 dashboard views, each answering a specific operational question.
+
+---
+
+## 3. Non-goals
+
+**NG1** — Aitra Meter does not make routing decisions. Routing is delegated to Aitra Gateway, LiteLLM, Envoy, or Kong.
+
+**NG2** — Aitra Meter does not compare GPU hardware tiers. Hardware comparison requires cross-cluster data and is a Phase 2 capability.
+
+**NG3** — Aitra Meter does not enforce budget gates in real-time. Budget reporting and alerting are in scope; real-time request blocking requires Aitra Gateway.
+
+**NG4** — Aitra Meter does not track individual user identity. User-level attribution requires Aitra Gateway to inject a user-ID header per request.
+
+**NG5** — Aitra Meter does not own fleet lifecycle, RMA tracking, or hardware refresh decisions. It exposes a J/token drift signal that DCIM tools consume.
+
+**NG6** — Cross-cluster views, Thanos federation, and supercluster topology are Phase 2.
+
+---
+
+## 4. System architecture
+
+### 4.1 Deployment topology
+
+Aitra Meter deploys as a set of Kubernetes workloads inside a single cluster. One Helm chart installs the full stack.
+
+```
+Kubernetes cluster
+├── DaemonSet: measurement-agent        (one pod per GPU node)
+├── Deployment: aggregation-service     (central computation and attribution)
+├── Deployment: dashboard               (Next.js, reads Prometheus + ClickHouse)
+├── CRD: MeasurementPolicy              (declarative measurement config)
+└── CRD: SiteConfig                     (per-cluster electricity cost, grid zone, PUE)
+```
+
+### 4.2 Data flow
+
+```
+GPU hardware
+  └─ NVML → Zeus ZeusMonitor → measurement-agent
+                                        │
+vLLM pods                               │
+  └─ /metrics Prometheus endpoint ──────┤
+                                        ▼
+                              aggregation-service
+                              (J/token computation,
+                               attribution resolution,
+                               calibration comparison)
+                                        │
+                          ┌─────────────┴─────────────┐
+                          ▼                           ▼
+                     Prometheus                  ClickHouse
+                     (hot metrics)           (time-series history)
+                          │                           │
+                   ┌──────┴──────────────────────────┘
+                   ▼
+         Dashboard / Grafana / OTel / Lago
+```
+
+### 4.3 External dependencies
+
+| Dependency | Role | Fallback |
+|---|---|---|
+| ElectricityMaps API | Live grid carbon intensity (gCO₂/kWh) | SiteConfig manual value |
+| WattTime API | Alternative carbon intensity (marginal emissions) | SiteConfig manual value |
+| OpenEI API | Electricity cost ($/kWh) by region | SiteConfig manual value |
+| Aitra Benchmark dataset | Primary calibration baseline | ML.ENERGY v3.0 (interim) |
+| ML.ENERGY Benchmark v3.0 | Interim calibration reference | Self-calibrated from production |
+
+All external dependencies have a manual ConfigMap fallback. Air-gapped clusters operate entirely from ConfigMap values.
+
+---
+
+## 5. Component specifications
+
+### 5.1 Measurement agent (DaemonSet)
+
+**Kind:** DaemonSet  
+**Image:** `ghcr.io/stevenphtan/aitra-meter/measurement-agent:v1`  
+**Node selector:** `aitra.io/gpu=true`  
+**Security context:** `hostPID: true`, `privileged: true`
+
+**Responsibilities:**
+- Initialize Zeus `ZeusMonitor` per GPU device on the node
+- Call Zeus `begin_window()` at the start of each vLLM request handling cycle
+- Call Zeus `end_window()` at completion, capturing joules for the window
+- Read `vllm:num_requests_running` from the local vLLM Prometheus endpoint to detect idle state
+- Emit per-window measurements to the aggregation service via gRPC
+
+**Supported hardware (via Zeus):**
+- NVIDIA GPUs: H100 SXM5, H200 SXM, L40S, B200 via NVML
+- AMD GPUs via ROCm telemetry
+- CPU and DRAM energy (secondary)
+
+**Multi-GPU handling:**  
+For tensor-parallel models (TP=2, TP=8), the agent reads all NVML device readings on the node and sums them. The aggregated node energy is emitted as a single measurement.
+
+**CV gate:**  
+Rolling coefficient of variation over last 100 windows. If CV > 3%, measurements are flagged `unstable=true` but not dropped.
+
+**Metrics emitted (Prometheus):**
+```
+aitra_gpu_energy_joules_total{node, gpu_id, model_name}
+aitra_gpu_power_watts{node, gpu_id}
+aitra_gpu_idle_power_watts{node, gpu_id}
+aitra_measurement_cv{node, model_name}
+aitra_measurement_window_stable{node, model_name}
+```
+
+---
+
+### 5.2 Aggregation service (Deployment)
+
+**Kind:** Deployment  
+**Replicas:** 1 (Phase 1)  
+**Image:** `ghcr.io/stevenphtan/aitra-meter/aggregation-service:v1`
+
+**Responsibilities:**
+- Receive per-window energy measurements from all measurement agents
+- Read `vllm:generation_tokens_total` from all vLLM Prometheus endpoints
+- Compute J/token = total energy ÷ total output tokens for the window
+- Resolve attribution dimensions from Kubernetes pod metadata
+- Apply calibration tier lookup for each workload × model × hardware combination
+- Derive gCO₂/token and $/M tokens from J/token × conversion factors
+- Write metrics to Prometheus and time-series records to ClickHouse
+
+**J/token computation — continuous batching:**
+
+| Method | Condition | Formula |
+|---|---|---|
+| `direct` | One vLLM instance per namespace | J/token = namespace_energy ÷ namespace_tokens |
+| `proportional` | Shared vLLM instance | J/token = cluster_J/token × (namespace_tokens ÷ cluster_tokens) |
+
+**Attribution dimensions:**
+
+| Dimension | Source | Required |
+|---|---|---|
+| `namespace` | Pod namespace | Yes |
+| `workload` | Pod annotation `aitra.io/workload` | No — `unknown` if absent |
+| `model` | vLLM metric label `model_name` | Yes |
+| `hardware` | Node label `gpu` | Yes |
+| `precision` | Pod annotation `aitra.io/precision` | No |
+| `team` | Pod annotation `aitra.io/team` | No |
+| `cost_centre` | Pod annotation `aitra.io/cost-centre` | No |
+
+**Calibration tier lookup (priority order):**
+1. `aitra_benchmark` — Aitra Benchmark published dataset
+2. `reference` — ML.ENERGY v3.0 dataset
+3. `self_calibrated` — Aitra Meter production measurements
+4. `uncalibrated` — no reference available
+
+**Metrics exposed:**
+```
+aitra_j_per_token{namespace, workload, model, hardware, precision, calibration_tier, attribution_method}
+aitra_co2_per_token_grams{namespace, workload, model, hardware, carbon_source}
+aitra_cost_per_million_tokens_usd{namespace, workload, model, hardware, cost_source}
+aitra_namespace_energy_joules_total{namespace, period, attribution_method}
+aitra_namespace_tokens_total{namespace, period}
+aitra_cluster_j_per_token{calibration_tier}
+aitra_cluster_power_watts_total
+aitra_idle_power_watts{node}
+aitra_idle_time_ratio{node}
+```
+
+---
+
+### 5.3 CRD: MeasurementPolicy
+
+```yaml
+apiVersion: aitra.io/v1alpha1
+kind: MeasurementPolicy
+metadata:
+  name: default
+  namespace: aitra-system
+spec:
+  scope:
+    namespaces: []
+  attribution:
+    defaultMethod: direct
+    namespaceOverrides:
+      - namespace: inference-shared
+        method: proportional
+  calibration:
+    preferredTier: aitra_benchmark
+  cv:
+    threshold: 0.03
+    windowSize: 100
+  budget:
+    - namespace: inference-fin
+      monthlyLimitUSD: 5000
+      alertThresholdPct: 80
+```
+
+---
+
+### 5.4 CRD: SiteConfig
+
+```yaml
+apiVersion: aitra.io/v1alpha1
+kind: SiteConfig
+metadata:
+  name: sgp-dc01
+  namespace: aitra-system
+spec:
+  gridZone: SG
+  electricityCostPerKwh: 0.12
+  pue: 1.35
+  carbonIntensityFallback: 412
+  carbonSource: electricitymaps
+```
+
+---
+
+## 6. Data model
+
+### 6.1 Measurement record
+
+```json
+{
+  "timestamp": "2026-05-22T14:30:00Z",
+  "cluster": "sgp-dc01",
+  "node": "gpu-node-01",
+  "namespace": "inference-prod",
+  "workload": "chat",
+  "model": "Qwen3.6-27B",
+  "hardware": "h100",
+  "precision": "fp16",
+  "team": "platform",
+  "cost_centre": "cc-1102",
+  "energy_joules": 412.4,
+  "output_tokens": 1328,
+  "j_per_token": 0.3105,
+  "calibration_tier": "aitra_benchmark",
+  "calibration_reference_j_per_token": 0.29,
+  "attribution_method": "direct",
+  "measurement_stable": true,
+  "cv": 0.018,
+  "grid_intensity_gco2_kwh": 412,
+  "carbon_source": "electricitymaps",
+  "co2_per_token_grams": 0.0000355,
+  "electricity_cost_per_kwh": 0.12,
+  "cost_source": "siteconfig",
+  "cost_per_million_tokens_usd": 0.0414,
+  "pue": 1.35,
+  "energy_joules_pue_adjusted": 556.7
+}
+```
+
+### 6.2 ClickHouse schema
+
+```sql
+CREATE TABLE aitra_measurements (
+  timestamp        DateTime,
+  cluster          LowCardinality(String),
+  namespace        LowCardinality(String),
+  workload         LowCardinality(String),
+  model            LowCardinality(String),
+  hardware         LowCardinality(String),
+  precision        LowCardinality(String),
+  j_per_token      Float32,
+  co2_per_token    Float32,
+  cost_per_m_tokens Float32,
+  output_tokens    UInt32,
+  energy_joules    Float32,
+  attribution_method LowCardinality(String),
+  calibration_tier LowCardinality(String),
+  measurement_stable UInt8,
+  cv               Float32
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (cluster, namespace, model, timestamp);
+```
+
+---
+
+## 7. Measurement methodology
+
+### 7.1 J/token computation
+
+```
+J/token = Σ GPU energy (joules) over measurement window
+          ÷ Σ output tokens generated over measurement window
+```
+
+### 7.2 Derived metrics
+
+```
+gCO₂/token  = J/token × (gCO₂/kWh ÷ 3,600,000)
+$/M tokens  = J/token × ($/kWh ÷ 3,600) × 1,000,000
+cluster J/token = Σ all node energy / Σ all output tokens
+```
+
+Derivation formula is stored with every record and surfaced in the dashboard.
+
+### 7.3 Idle energy
+
+Idle energy: GPU power draw when `vllm:num_requests_running = 0`, sampled at 10 Hz via NVML. Tracked separately, not included in J/token computation.
+
+### 7.4 PUE adjustment
+
+```
+energy_pue_adjusted = energy_measured × PUE
+```
+
+PUE configured in `SiteConfig`. Shown as a configured input alongside raw measured energy.
+
+---
+
+## 8. Calibration
+
+### 8.1 Tiers
+
+| Tier | Source | When used |
+|---|---|---|
+| `aitra_benchmark` | Aitra Benchmark (Singapore AI Lab) | When published and covering the combination |
+| `reference` | ML.ENERGY v3.0 (NeurIPS 2025) | When Aitra Benchmark does not cover it |
+| `self_calibrated` | Aitra Meter production measurements | When neither covers it |
+| `uncalibrated` | No reference available | New models |
+
+### 8.2 Known ML.ENERGY v3.0 gaps
+
+| Gap | Handling |
+|---|---|
+| L40S not covered | Hardware scaling factor from H100 baseline |
+| FP8-PQ not primary | `self_calibrated` tier |
+| APAC models (DeepSeek, MiniMax, Qwen new variants) | `self_calibrated` |
+| J/response not J/token | Divide by average output token count per workload type |
+| vLLM version drift | Flag calibration as potentially stale on version change |
+
+---
+
+## 9. Attribution model
+
+### 9.1 Annotation contract
+
+**Node labels (operator responsibility):**
+```yaml
+labels:
+  gpu: h100
+  aitra.io/gpu: "true"
+```
+
+**Pod annotations (operator responsibility):**
+```yaml
+annotations:
+  aitra.io/workload: chat
+  aitra.io/precision: fp16
+  aitra.io/team: platform
+  aitra.io/cost-centre: cc-1102
+```
+
+Missing annotations result in `unknown` for the dimension — records are not dropped.
+
+---
+
+## 10. Dashboard views — Phase 1
+
+### View 1 — J/token by workload × model × hardware
+Live table of every active combination. Calibration tier badge per row. Warning when workload label is absent. Updated on each Prometheus scrape.
+
+### View 2a — Consumption over time, cluster
+Cluster-wide aggregate. Cluster J/token rolling trend. Total power and throughput on paired axes. Time window: 1h / 6h / 24h / 7d.
+
+### View 2b — Consumption over time, by series
+One line per active workload × model × hardware combination. Toggle between cluster and series view.
+
+### View 3 — Energy consumed by namespace
+Total joules, tokens, cost per namespace per billing period. PUE slider (live). Attribution method declared per row. Exportable.
+
+### View 4 — Idle consumption
+GPU power draw when `vllm:num_requests_running = 0`. Stacked area chart (serving vs idle). Per-node table with idle draw, idle energy per hour, serving/idle time split.
+
+### View 5 — Carbon and cost per token
+gCO₂/token and $/M tokens per combination. Data source labeled (live API / last-known / manual). Derivation formula shown inline. 24h grid intensity chart.
+
+---
+
+## 11. CNCF integration specifications
+
+### Prometheus
+Native ServiceMonitor. Auto-registers with kube-prometheus-stack. No new Prometheus instance required.
+
+### OpenTelemetry
+OTel Collector sidecar. Aggregation service emits via OTLP. Energy cost annotations attached to trace spans when W3C TraceContext is present.
+
+### Envoy
+Phase 1: Access log ingestion via Fluentbit for attribution enrichment on Istio/Envoy mesh clusters.
+Aitra Gateway: ext_proc for attribution header injection, ext_authz for budget enforcement.
+
+### OpenCost
+Shared Prometheus backend. Complementary metrics. OpenCost MCP server integration is Phase 2.
+
+### KEDA
+ScaledObject using `aitra_j_per_token` or `aitra_idle_time_ratio` as Prometheus triggers. Configuration is operator responsibility.
+
+---
+
+## 12. Helm chart
+
+Key values: see `helm/aitra-meter/values.yaml`.
+
+RBAC requirements — measurement agent:
+```yaml
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["aitra.io"]
+  resources: ["measurementpolicies", "siteconfigs"]
+  verbs: ["get", "list", "watch"]
+```
+
+No write permissions required on any Kubernetes resource.
+
+---
+
+## 13. Security and compliance
+
+- No PII in measurement records by default. `aitra.io/user-id` is opt-in.
+- Air-gapped mode: all external API calls disabled via `airGapped: true`.
+- MAS-regulated deployments: air-gapped mode + offline Helm + pre-pulled images.
+- External API keys stored in Kubernetes Secrets, never in ConfigMaps or logs.
+
+---
+
+## 14. Acceptance criteria — Phase 1
+
+| ID | Criterion | Verification |
+|---|---|---|
+| AC-1 | Measurement agent produces NVML readings within 60s of pod start | DaemonSet rollout + metric presence |
+| AC-2 | J/token CV < 3% over 100-request window for stable workloads | `aitra_measurement_cv` metric |
+| AC-3 | Cluster J/token = Σ energy ÷ Σ tokens (not average of series) | Integration test |
+| AC-4 | Attribution method stored in every measurement record | ClickHouse inspection |
+| AC-5 | All six dashboard views render within 5s | Load time test |
+| AC-6 | PUE slider updates all namespace cost figures within 200ms | UI interaction test |
+| AC-7 | Derivation formula shown inline for every gCO₂/token and $/M tokens value | Visual inspection |
+| AC-8 | `workload=unknown` rows appear for pods with no annotation | Deploy unlabeled pod |
+| AC-9 | Helm install completes on air-gapped cluster | Offline install test |
+| AC-10 | ServiceMonitor auto-registers with kube-prometheus-stack | Install + ServiceMonitor inspection |
+| AC-11 | 30-day namespace chargeback query completes within 10s | ClickHouse load test |
+| AC-12 | Carbon figures update when API switches to fallback | API failure simulation |
+
+---
+
+## 15. Phase 2 scope (out of scope for this specification)
+
+- Multi-cluster federation via Thanos
+- Supercluster topology (cross-cluster tensor parallelism)
+- Cross-cluster TCO comparison view
+- Workload routing recommendation view
+- Prefill vs decode energy separation
+- Aitra Benchmark publication
+- OpenCost MCP server formal integration
+- Per-request attribution within continuous batching (requires Aitra Gateway)
+- Hardware efficiency drift alerting via DCIM API
+- Langfuse quality + efficiency correlation views
+
+---
+
+*Aitra Meter · Technical Specification v1.0 · SODA Foundation · Apache 2.0 · May 2026*  
+*github.com/stevenphtan/aitra-meter · Singapore AI Lab · Tsinghua University / LF Research*

--- a/helm/aitra-meter/Chart.yaml
+++ b/helm/aitra-meter/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: aitra-meter
+description: Open-source Kubernetes-native AI inference efficiency measurement
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+keywords:
+  - ai
+  - inference
+  - efficiency
+  - observability
+  - kubernetes
+  - gpu
+  - energy
+
+home: https://github.com/stevenphtan/aitra-meter
+sources:
+  - https://github.com/stevenphtan/aitra-meter
+
+maintainers:
+  - name: stevenphtan
+    url: https://github.com/stevenphtan
+
+dependencies:
+  - name: clickhouse
+    version: ">=0.1.0"
+    repository: https://charts.clickhouse.io
+    condition: clickhouse.enabled

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -1,0 +1,117 @@
+# Aitra Meter Helm chart values
+# See docs/spec/aitra-meter-spec-v1.0.md for full specification
+
+cluster:
+  # Name of this cluster — used as a label on all measurements
+  name: ""
+
+measurementAgent:
+  image:
+    repository: ghcr.io/stevenphtan/aitra-meter/measurement-agent
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+  # Node selector — DaemonSet only schedules to nodes with this label
+  nodeSelector:
+    aitra.io/gpu: "true"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # CV gate: flag measurements with rolling CV above this threshold
+  cvThreshold: 0.03
+  cvWindowSize: 100
+
+aggregationService:
+  image:
+    repository: ghcr.io/stevenphtan/aitra-meter/aggregation-service
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+  port: 8080
+
+dashboard:
+  enabled: true
+  image:
+    repository: ghcr.io/stevenphtan/aitra-meter/dashboard
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 3000
+  service:
+    type: ClusterIP
+
+# Prometheus integration
+prometheus:
+  serviceMonitor:
+    enabled: true
+    # Namespace where Prometheus Operator is installed
+    namespace: monitoring
+    interval: 15s
+    scrapeTimeout: 10s
+
+# ClickHouse — for historical time-series storage
+# Set enabled: false to use an external ClickHouse instance
+clickhouse:
+  enabled: true
+  auth:
+    username: aitra
+    password: ""  # set via secret in production
+  persistence:
+    enabled: true
+    size: 50Gi
+
+# Site configuration — maps to SiteConfig CRD
+siteConfig:
+  # ElectricityMaps zone identifier (https://app.electricitymaps.com/map)
+  gridZone: ""
+  electricityCostPerKwh: 0.12
+  # PUE applied as multiplier in chargeback views
+  pue: 1.35
+  # Carbon intensity fallback (gCO2/kWh) used when API is unavailable
+  carbonIntensityFallback: 400
+  # Carbon source: electricitymaps | watttime | manual
+  carbonSource: electricitymaps
+
+# External API credentials
+# Store in Kubernetes secrets and reference by name
+externalApis:
+  electricityMaps:
+    enabled: true
+    secretName: aitra-electricitymaps-token
+    secretKey: token
+  wattTime:
+    enabled: false
+    secretName: aitra-watttime-credentials
+  openEI:
+    enabled: false
+
+# Air-gapped mode: disable all external API calls
+# All conversion factors are read from siteConfig values above
+airGapped:
+  enabled: false
+
+# Default MeasurementPolicy — applied to all namespaces unless overridden
+measurementPolicy:
+  defaultAttributionMethod: direct  # direct | proportional
+  calibration:
+    preferredTier: aitra_benchmark  # aitra_benchmark | reference | self_calibrated
+  budget:
+    enabled: false
+    # Per-namespace budget limits — configure per namespace
+    namespaces: []
+    # - namespace: inference-prod
+    #   monthlyLimitUSD: 10000
+    #   alertThresholdPct: 80
+
+# Namespace where Aitra Meter is installed
+namespaceOverride: ""


### PR DESCRIPTION
## Initial project setup

This PR establishes the full documentation and scaffold for Aitra Meter Phase 1.

### What's included

**Documentation**
- `README.md` — project overview, quick start, architecture summary, view index
- `docs/spec/aitra-meter-spec-v1.0.md` — full technical specification (goals, non-goals, component specs, data model, measurement methodology, attribution model, calibration, dashboard views, CNCF integrations, Helm spec, acceptance criteria)
- `docs/adr/0001-kubernetes-native-daemonset.md` — why DaemonSet with hostPID
- `docs/adr/0002-zeus-measurement-engine.md` — why Zeus over custom NVML wrapper
- `docs/adr/0003-proportional-attribution.md` — attribution method for shared vLLM instances

**Governance**
- `LICENSE` — Apache 2.0
- `GOVERNANCE.md` — SODA Foundation governance model
- `CONTRIBUTING.md` — contribution guide
- `CODE_OF_CONDUCT.md` — CNCF Code of Conduct reference
- `MAINTAINERS.md`

**Scaffold**
- `helm/aitra-meter/Chart.yaml` — Helm chart metadata
- `helm/aitra-meter/values.yaml` — full annotated values
- `config/crd/measurementpolicy.yaml` — MeasurementPolicy CRD
- `config/crd/siteconfig.yaml` — SiteConfig CRD

### What comes next

After this PR is merged:
1. Scaffold the Go module (`cmd/measurement-agent`, `cmd/aggregation-service`, `api/v1alpha1/`)
2. Implement the measurement agent DaemonSet (Zeus + NVML integration)
3. Implement the aggregation service (J/token computation, attribution, ClickHouse writes)
4. Implement Phase 1 dashboard views

### Review notes

- The spec is the source of truth. All implementation work should reference acceptance criteria AC-1 through AC-12.
- Attribution method (direct vs proportional) is the most important design decision for chargeback accuracy. See ADR 0003 and Section 9 of the spec.
- The calibration tier system (aitra_benchmark → reference → self_calibrated) is intentionally designed to degrade gracefully when Aitra Benchmark data is not yet published.
