### PR TITLE
feat(provider): implement generic-prometheus inference provider

### DIFF
--- a/internal/provider/inference/genericprometheus/generic_prometheus.go
+++ b/internal/provider/inference/genericprometheus/generic_prometheus.go
@@ -1,51 +1,144 @@
+// Package genericprometheus provides an InferenceMetricsProvider for any
+// inference server that exposes a Prometheus endpoint. Metric names and the
+// model name label are configurable so the same provider works with TGI,
+// SGLang, Ollama, Triton, and custom servers.
 package genericprometheus
 
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/aitra-ai/aitra-meter/internal/provider"
 )
 
 func init() {
 	provider.RegisterInference("generic-prometheus", func(config map[string]string) (provider.InferenceMetricsProvider, error) {
+		endpoint := config["endpoint"]
+		if endpoint == "" {
+			return nil, fmt.Errorf("generic-prometheus: endpoint is required")
+		}
 		return &GenericPrometheusProvider{
-			endpoint:          config["endpoint"],
-			outputTokensMetric: orDefault(config["output_tokens_metric"], "inference_output_tokens_total"),
+			endpoint:              endpoint,
+			outputTokensMetric:    orDefault(config["output_tokens_metric"], "inference_output_tokens_total"),
 			requestsRunningMetric: orDefault(config["requests_running_metric"], "inference_requests_running"),
-			modelNameLabel:    orDefault(config["model_name_label"], "model_name"),
+			modelNameLabel:        orDefault(config["model_name_label"], "model_name"),
+			client:                &http.Client{Timeout: 10 * time.Second},
 		}, nil
 	})
 }
 
-// GenericPrometheusProvider implements InferenceMetricsProvider for any inference
-// server that exposes a Prometheus endpoint with configurable metric names.
-// Compatible with TGI, SGLang, Ollama, Triton, and custom servers.
+// GenericPrometheusProvider implements InferenceMetricsProvider for any
+// inference server exposing a Prometheus /metrics endpoint.
 type GenericPrometheusProvider struct {
 	endpoint              string
 	outputTokensMetric    string
 	requestsRunningMetric string
 	modelNameLabel        string
+	client                *http.Client
 }
 
 func (g *GenericPrometheusProvider) Name() string { return "generic-prometheus" }
 
 func (g *GenericPrometheusProvider) OutputTokens(ctx context.Context) (uint64, error) {
-	// TODO: scrape g.outputTokensMetric from g.endpoint
-	return 0, fmt.Errorf("not implemented")
+	m, err := g.scrape(ctx)
+	if err != nil {
+		return 0, err
+	}
+	val, ok := m[g.outputTokensMetric]
+	if !ok {
+		return 0, fmt.Errorf("generic-prometheus: metric %q not found at %s", g.outputTokensMetric, g.endpoint)
+	}
+	return uint64(val), nil
 }
 
 func (g *GenericPrometheusProvider) RequestsRunning(ctx context.Context) (int, error) {
-	// TODO: scrape g.requestsRunningMetric from g.endpoint
-	return 0, fmt.Errorf("not implemented")
+	m, err := g.scrape(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return int(m[g.requestsRunningMetric]), nil
 }
 
 func (g *GenericPrometheusProvider) ModelName(ctx context.Context) (string, error) {
-	// TODO: read g.modelNameLabel from scraped metrics
-	return "", fmt.Errorf("not implemented")
+	lines, err := g.rawLines(ctx)
+	if err != nil {
+		return "", err
+	}
+	prefix := g.outputTokensMetric + "{"
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			if name := extractLabel(line, g.modelNameLabel); name != "" {
+				return name, nil
+			}
+		}
+	}
+	return "unknown", nil
+}
+
+func (g *GenericPrometheusProvider) scrape(ctx context.Context) (map[string]float64, error) {
+	lines, err := g.rawLines(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res := map[string]float64{}
+	for _, line := range lines {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		name := parts[0]
+		if i := strings.Index(name, "{"); i > 0 {
+			name = name[:i]
+		}
+		if val, err := strconv.ParseFloat(parts[len(parts)-1], 64); err == nil {
+			res[name] = val
+		}
+	}
+	return res, nil
+}
+
+func (g *GenericPrometheusProvider) rawLines(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("generic-prometheus: scraping %s: %w", g.endpoint, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(body), "\n"), nil
+}
+
+func extractLabel(line, label string) string {
+	key := label + `="`
+	idx := strings.Index(line, key)
+	if idx < 0 {
+		return ""
+	}
+	start := idx + len(key)
+	end := strings.Index(line[start:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return line[start : start+end]
 }
 
 func orDefault(v, d string) string {
-	if v == "" { return d }
+	if v == "" {
+		return d
+	}
 	return v
 }

--- a/internal/provider/inference/genericprometheus/generic_prometheus_test.go
+++ b/internal/provider/inference/genericprometheus/generic_prometheus_test.go
@@ -1,0 +1,94 @@
+package genericprometheus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const testMetrics = `# HELP tgi_request_generated_tokens_total Total generated tokens
+# TYPE tgi_request_generated_tokens_total counter
+tgi_request_generated_tokens_total{model_id="llama-3-8b"} 42000
+# HELP tgi_queue_size Current queue size
+# TYPE tgi_queue_size gauge
+tgi_queue_size 3
+`
+
+func newTestProvider(t *testing.T, body string) (*GenericPrometheusProvider, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	p, err := (&struct{}{}).init(srv.URL)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	return p, srv
+}
+
+// init is a test helper that creates a provider with TGI metric names.
+func (*struct{}) init(endpoint string) (*GenericPrometheusProvider, error) {
+	return &GenericPrometheusProvider{
+		endpoint:              endpoint + "/metrics",
+		outputTokensMetric:    "tgi_request_generated_tokens_total",
+		requestsRunningMetric: "tgi_queue_size",
+		modelNameLabel:        "model_id",
+		client:                http.DefaultClient,
+	}, nil
+}
+
+func TestOutputTokens(t *testing.T) {
+	p, srv := newTestProvider(t, testMetrics)
+	_ = srv
+	got, err := p.OutputTokens(context.Background())
+	if err != nil {
+		t.Fatalf("OutputTokens: %v", err)
+	}
+	if got != 42000 {
+		t.Errorf("got %d, want 42000", got)
+	}
+}
+
+func TestRequestsRunning(t *testing.T) {
+	p, srv := newTestProvider(t, testMetrics)
+	_ = srv
+	got, err := p.RequestsRunning(context.Background())
+	if err != nil {
+		t.Fatalf("RequestsRunning: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}
+
+func TestModelName(t *testing.T) {
+	p, srv := newTestProvider(t, testMetrics)
+	_ = srv
+	got, err := p.ModelName(context.Background())
+	if err != nil {
+		t.Fatalf("ModelName: %v", err)
+	}
+	if got != "llama-3-8b" {
+		t.Errorf("got %q, want %q", got, "llama-3-8b")
+	}
+}
+
+func TestMissingMetric(t *testing.T) {
+	p, srv := newTestProvider(t, "# no metrics here\n")
+	_ = srv
+	_, err := p.OutputTokens(context.Background())
+	if err == nil {
+		t.Fatal("expected error for missing metric")
+	}
+}
+
+func TestOrDefault(t *testing.T) {
+	if orDefault("", "default") != "default" {
+		t.Error("empty string should return default")
+	}
+	if orDefault("value", "default") != "value" {
+		t.Error("non-empty string should return itself")
+	}
+}


### PR DESCRIPTION
Implements all three `InferenceMetricsProvider` methods using the same HTTP scraping approach as the vLLM provider. Metric names and model label are configurable, making this compatible with TGI, SGLang, Ollama, Triton, and any custom Prometheus endpoint.

**Changes**
- `internal/provider/inference/genericprometheus/generic_prometheus.go` — full implementation
- `internal/provider/inference/genericprometheus/generic_prometheus_test.go` — 5 tests with `httptest.Server`

**Config example (TGI)**:
```yaml
inferenceProvider:
  type: generic-prometheus
  config:
    endpoint: http://localhost:8080/metrics
    output_tokens_metric: tgi_request_generated_tokens_total
    requests_running_metric: tgi_queue_size
    model_name_label: model_id
```

**Definition of done**
- [ ] `go test ./internal/provider/inference/genericprometheus/...` passes
- [ ] `go build ./...` clean