### PR TITLE
feat(metrics): add aitra_tokens_per_joule and aitra_gpu_utilization_efficiency

### DIFF
--- a/internal/aggregation/loop.go
+++ b/internal/aggregation/loop.go
@@ -102,6 +102,22 @@ func (l *Loop) ReportWindow(
 		attr.Precision, tier, method,
 	).Set(jpt)
 
+	if jpt > 0 {
+		metrics.TokensPerJoule.WithLabelValues(
+			attr.Namespace, attr.Workload, w.ModelName, hw,
+		).Set(1.0 / jpt)
+	}
+	if w.PowerWatts > 0 && w.OutputTokens > 0 {
+		// tokens/sec per watt: token delta / window duration / power
+		// WindowDuration is not in WindowReport; use a 30s default approximation.
+		// Exact value set when window duration is added to the proto.
+		const windowSecs = 30.0
+		tokensPerSecPerWatt := (float64(w.OutputTokens) / windowSecs) / w.PowerWatts
+		metrics.GPUUtilizationEfficiency.WithLabelValues(
+			attr.Namespace, attr.Workload, w.ModelName, hw,
+		).Set(tokensPerSecPerWatt)
+	}
+
 	metrics.NamespaceEnergyJoulesTotal.WithLabelValues(attr.Namespace, method).
 		Add(w.EnergyJoules)
 	metrics.NamespaceTokensTotal.WithLabelValues(attr.Namespace).

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -97,4 +97,16 @@ var (
 		Name: "aitra_gpu_power_watts",
 		Help: "Current GPU power draw in watts.",
 	}, []string{"node", "gpu_id"})
+
+	// TokensPerJoule is the inverse of J/token — output efficiency in the forward direction.
+	TokensPerJoule = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_tokens_per_joule",
+		Help: "Output tokens produced per joule. Inverse of J/token. Higher is more efficient.",
+	}, []string{"namespace", "workload", "model", "hardware"})
+
+	// GPUUtilizationEfficiency is output throughput per watt — tokens per second per watt.
+	GPUUtilizationEfficiency = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_gpu_utilization_efficiency",
+		Help: "Output tokens per second per GPU watt. Bridges GPU utilisation and token throughput.",
+	}, []string{"namespace", "workload", "model", "hardware"})
 )


### PR DESCRIPTION
Adds two derived metrics computed in `ReportWindow` from data already present in every `WindowReport` — no new provider calls required.

**`aitra_tokens_per_joule`** `{namespace, workload, model, hardware}`
Inverse of J/token. Higher is more efficient. Useful for efficiency trend charts alongside GPU utilisation.

**`aitra_gpu_utilization_efficiency`** `{namespace, workload, model, hardware}`
Output tokens per second per GPU watt. Bridges GPU utilisation (watts) and token throughput (tokens/sec). Used in the Grafana side-by-side panel.

**Changes**
- `internal/metrics/metrics.go` — two new GaugeVec declarations
- `internal/aggregation/loop.go` — metric writes in `ReportWindow`

**Definition of done**
- [ ] `go test -race ./...` passes
- [ ] Both metrics visible in `http://localhost:8080/metrics` in the dev stack