### PR TITLE
feat(grafana): pre-built dashboard JSON and reference alerting rules

### DIFF
--- a/examples/alerting-rules.yaml
+++ b/examples/alerting-rules.yaml
@@ -1,0 +1,52 @@
+# Aitra Meter — reference Prometheus alerting rules.
+# Apply with: kubectl apply -f examples/alerting-rules.yaml
+# Or mount via the Prometheus Operator PrometheusRule CRD.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: aitra-meter
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: aitra-meter
+      rules:
+        - alert: AIEfficiencyRegression
+          expr: |
+            aitra_j_per_token
+            > on(namespace, model, hardware)
+            (avg_over_time(aitra_j_per_token[1h]) * 1.20)
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "J/token increased >20% over 1-hour rolling average"
+            description: >
+              {{ $labels.namespace }}/{{ $labels.model }} on {{ $labels.hardware }}:
+              J/token is {{ $value | humanize }} — more than 20% above the 1h average.
+
+        - alert: GPUIdleExcessive
+          expr: aitra_idle_time_ratio > 0.40
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "GPU idle >40% for 30 minutes"
+            description: >
+              Node {{ $labels.node }} has been idle {{ $value | humanizePercentage }}
+              of the last hour. Consider scaling down or consolidating workloads.
+
+        - alert: MeasurementUnstable
+          expr: aitra_measurement_cv > 0.03
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "J/token CV >3% — measurement window flagged unstable"
+            description: >
+              Node {{ $labels.node }}, model {{ $labels.model_name }}:
+              CV is {{ $value | humanizePercentage }}. Check for workload
+              interference or GPU thermal throttling.

--- a/helm/aitra-meter/files/grafana-dashboard.json
+++ b/helm/aitra-meter/files/grafana-dashboard.json
@@ -1,0 +1,137 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "title": "Aitra Meter",
+  "uid": "aitra-meter-v1",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["aitra", "ai", "inference", "energy"],
+  "panels": [
+    {
+      "id": 1,
+      "title": "J/token vs GPU utilisation",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_j_per_token",
+          "legendFormat": "J/token — {{model}} {{hardware}}",
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "nvidia_gpu_utilization / 100",
+          "legendFormat": "GPU util — {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": [
+          { "matcher": { "id": "byNamePattern", "options": "J/token.*" },
+            "properties": [{ "id": "unit", "value": "joule" }] }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "title": "Tokens per joule",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_tokens_per_joule",
+          "legendFormat": "tokens/J — {{namespace}} {{model}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "id": 3,
+      "title": "Idle time ratio",
+      "type": "gauge",
+      "gridPos": { "x": 0, "y": 8, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_idle_time_ratio",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0, "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.3 },
+              { "color": "red", "value": 0.4 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Measurement CV",
+      "type": "gauge",
+      "gridPos": { "x": 6, "y": 8, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_measurement_cv",
+          "legendFormat": "{{node}} {{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0, "max": 0.1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.02 },
+              { "color": "red", "value": 0.03 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Cost per million tokens (USD)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 4 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_cost_per_million_tokens_usd",
+          "legendFormat": "{{namespace}} {{model}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Grafana dashboard that auto-provisions via Grafana sidecar when `grafana.enabled=true`. Also adds three reference `PrometheusRule` alerting rules.

**Dashboard panels** (`helm/aitra-meter/files/grafana-dashboard.json`):
- `nvidia_gpu_utilization` alongside `aitra_j_per_token` side-by-side
- `aitra_tokens_per_joule` trend per namespace/model
- Idle time ratio gauge (threshold 0.40)
- Measurement CV gauge (threshold 0.03)
- Cost per million tokens USD per namespace

**Alerting rules** (`examples/alerting-rules.yaml`):
- `AIEfficiencyRegression` — J/token >20% above 1h rolling average for 10m
- `GPUIdleExcessive` — idle ratio >40% for 30m
- `MeasurementUnstable` — CV >3% for 5m

**Definition of done**
- [ ] Dashboard JSON valid (`grafana-dashboard-lint` or import into Grafana)
- [ ] `helm lint helm/aitra-meter` passes