### PR TITLE
Integration: KEDA ScaledObjects, OpenCost combined Grafana panel, and integration guides

### DIFF
--- a/docs/guides/keda-integration.md
+++ b/docs/guides/keda-integration.md
@@ -1,0 +1,54 @@
+# KEDA integration
+
+Aitra Meter exposes `aitra_j_per_token` and `aitra_idle_time_ratio` as Prometheus
+metrics. KEDA can trigger autoscaling on either.
+
+## Prerequisites
+
+KEDA installed in the cluster:
+
+```bash
+helm install keda kedacore/keda --namespace keda --create-namespace
+```
+
+Aitra Meter installed and producing measurements. Verify:
+
+```bash
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+# http://localhost:9090/graph?g0.expr=aitra_idle_time_ratio
+```
+
+## Scale to zero on idle
+
+Apply the reference ScaledObject:
+
+```bash
+kubectl apply -f examples/keda/scale-on-idle.yaml
+```
+
+When `aitra_idle_time_ratio` exceeds 0.40 for 300 seconds, KEDA scales the
+`inference-chat` Deployment to zero. Replicas scale back up when requests resume.
+
+Watch it work:
+
+```bash
+kubectl get events -n inference-prod --sort-by='.lastTimestamp' | grep ScaledObject
+```
+
+## Scale on efficiency regression
+
+```bash
+kubectl apply -f examples/keda/scale-on-efficiency-regression.yaml
+```
+
+Triggers when J/token exceeds 120% of its 1-hour prior value. Useful for
+detecting model version regressions or GPU thermal throttling.
+
+## Customising
+
+Edit `scaleTargetRef.name` to match your Deployment name. Edit the `query`
+label selectors to match your namespace and model. The `threshold` is a string
+representation of the numeric threshold.
+
+Both ScaledObjects use the standard `prometheus` KEDA trigger — no additional
+KEDA plugins required.

--- a/docs/guides/opencost-integration.md
+++ b/docs/guides/opencost-integration.md
@@ -1,0 +1,35 @@
+# OpenCost integration
+
+OpenCost and Aitra Meter are complementary. OpenCost measures $/GPU-hr —
+what the infrastructure costs. Aitra Meter measures $/M tokens — what the
+inference produces per million output tokens.
+
+The combined Grafana panel makes the inversion visible: a namespace that
+looks cheaper per GPU-hour can be more expensive per token due to poor
+batching. Neither tool reveals this alone.
+
+## Prerequisites
+
+OpenCost installed with a shared Prometheus backend:
+
+```bash
+helm install opencost opencost/opencost --namespace opencost --create-namespace
+```
+
+Aitra Meter installed (shares the same Prometheus instance).
+
+## Import the combined panel
+
+1. Open Grafana → Dashboards → Import
+2. Upload `examples/grafana/opencost-aitra-combined.json`
+3. Select your Prometheus datasource
+
+The left panel shows OpenCost GPU allocation cost per namespace.
+The right panel shows Aitra `aitra_cost_per_million_tokens_usd` per namespace.
+
+## Interpreting the inversion
+
+If `inference-staging` shows lower $/GPU-hr than `inference-prod` but higher
+$/M tokens, `staging` has worse model serving configuration despite cheaper
+hardware. The right optimisation target is batching and concurrency, not
+hardware tier.

--- a/examples/grafana/opencost-aitra-combined.json
+++ b/examples/grafana/opencost-aitra-combined.json
@@ -1,0 +1,37 @@
+{
+  "title": "OpenCost + Aitra — Cost per namespace",
+  "uid": "opencost-aitra-combined",
+  "schemaVersion": 38,
+  "panels": [
+    {
+      "id": 1,
+      "title": "$/GPU-hr per namespace (OpenCost)",
+      "description": "Infrastructure cost from OpenCost — what the hardware costs per hour",
+      "type": "bargauge",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (namespace) (container_cpu_allocation_cost + container_memory_allocation_cost + container_gpu_allocation_cost)",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    },
+    {
+      "id": 2,
+      "title": "$/M tokens per namespace (Aitra)",
+      "description": "Output-linked cost from Aitra Meter — what the inference produces per million tokens",
+      "type": "bargauge",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "aitra_cost_per_million_tokens_usd",
+          "legendFormat": "{{namespace}} {{model}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    }
+  ]
+}

--- a/examples/keda/scale-on-efficiency-regression.yaml
+++ b/examples/keda/scale-on-efficiency-regression.yaml
@@ -1,0 +1,25 @@
+# Trigger a scaling event when J/token exceeds 120% of its value from 1 hour ago.
+# This surfaces efficiency regressions as an autoscaling signal — useful for
+# triggering a deployment rollback or an alert-driven scale-out.
+#
+# Apply:
+#   kubectl apply -f examples/keda/scale-on-efficiency-regression.yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: inference-efficiency-alert
+  namespace: inference-prod
+spec:
+  scaleTargetRef:
+    name: inference-chat
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus-operated.monitoring.svc.cluster.local:9090
+        metricName: aitra_j_per_token_regression_ratio
+        query: >
+          aitra_j_per_token{namespace="inference-prod",model="Qwen3.6-27B"}
+          / on()
+          aitra_j_per_token{namespace="inference-prod",model="Qwen3.6-27B"}
+          offset 1h
+        threshold: "1.20"

--- a/examples/keda/scale-on-idle.yaml
+++ b/examples/keda/scale-on-idle.yaml
@@ -1,0 +1,26 @@
+# Scale inference Deployment to zero when idle_time_ratio exceeds 0.40
+# for 300 seconds. Replicas scale back up when requests resume.
+#
+# Prerequisites:
+#   helm install keda kedacore/keda --namespace keda --create-namespace
+#
+# Apply:
+#   kubectl apply -f examples/keda/scale-on-idle.yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: inference-idle-scaledown
+  namespace: inference-prod
+spec:
+  scaleTargetRef:
+    name: inference-chat
+  minReplicaCount: 0
+  maxReplicaCount: 4
+  cooldownPeriod: 300
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus-operated.monitoring.svc.cluster.local:9090
+        metricName: aitra_idle_time_ratio
+        query: aitra_idle_time_ratio{namespace="inference-prod"}
+        threshold: "0.4"


### PR DESCRIPTION
Adds reference YAML and documentation for KEDA autoscaling and OpenCost cost comparison. No new Go code.

**KEDA** (`examples/keda/`):
- `scale-on-idle.yaml` — scale to zero when `aitra_idle_time_ratio > 0.40` for 300s
- `scale-on-efficiency-regression.yaml` — trigger when J/token >120% of 1h prior value

**OpenCost** (`examples/grafana/`):
- `opencost-aitra-combined.json` — side-by-side $/GPU-hr (OpenCost) vs $/M tokens (Aitra)

**Guides** (`docs/guides/`):
- `keda-integration.md` — prerequisites, apply, kubectl verification
- `opencost-integration.md` — panel import, inversion interpretation

Both KEDA ScaledObjects use the standard `prometheus` trigger — no additional KEDA plugins required.

**Definition of done**
- [ ] `kubectl apply --dry-run=client -f examples/keda/scale-on-idle.yaml` succeeds
- [ ] Combined panel imports cleanly into Grafana