### PR TITLE
feat(metrics): AI efficiency metric family — model token/energy primitives (part of #40)

### DIFF
--- a/cmd/aggregation-service/main.go
+++ b/cmd/aggregation-service/main.go
@@ -34,10 +34,14 @@ import (
 
 func main() {
 	metricsAddr := flag.String("metrics-addr", ":8080", "Prometheus metrics and API listen address")
-	grpcAddr    := flag.String("grpc-addr",    ":9091", "gRPC listen address for measurement agents")
-	clusterName := flag.String("cluster",      "",      "Cluster name (required)")
-	kubeconfig  := flag.String("kubeconfig",   "",      "Path to kubeconfig (empty = in-cluster)")
-	logLevel    := flag.String("log-level",    "info",  "Log level: debug | info | warn | error")
+	grpcAddr := flag.String("grpc-addr", ":9091", "gRPC listen address for measurement agents")
+	clusterName := flag.String("cluster", "", "Cluster name (required)")
+	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig (empty = in-cluster)")
+	logLevel := flag.String("log-level", "info", "Log level: debug | info | warn | error")
+	costPerKWh := flag.Float64("electricity-cost-per-kwh", envFloat("ELECTRICITY_COST_PER_KWH", 0), "Electricity cost USD/kWh for cost derivation (0 = off)")
+	gridGCO2 := flag.Float64("grid-gco2-per-kwh", envFloat("GRID_GCO2_PER_KWH", 0), "Grid carbon intensity gCO2/kWh for carbon derivation (0 = off)")
+	carbonSource := flag.String("carbon-source", envStr("CARBON_SOURCE", "manual"), "carbon_source metric label")
+	costSource := flag.String("cost-source", envStr("COST_SOURCE", "manual"), "cost_source metric label")
 	flag.Parse()
 
 	if *clusterName == "" {
@@ -90,6 +94,12 @@ func main() {
 		aggregation.NewCalibrationTableFromMap(nil),
 		k8slookup.NewNodeHardwareLookup(k8sClient),
 		backend,
+		aggregation.SiteParams{
+			ElectricityCostPerKWh: *costPerKWh,
+			GridGCO2PerKWh:        *gridGCO2,
+			CarbonSource:          *carbonSource,
+			CostSource:            *costSource,
+		},
 	)
 
 	// --- gRPC server -------------------------------------------------------
@@ -167,6 +177,24 @@ func newLogger(level string) *zap.Logger {
 	_ = cfg.Level.UnmarshalText([]byte(level))
 	l, _ := cfg.Build()
 	return l
+}
+
+// envStr returns the environment variable value or def when unset/empty.
+func envStr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// envFloat parses a float environment variable, returning def when unset or invalid.
+func envFloat(key string, def float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
 }
 
 func buildK8sClient(kubeconfigPath string) (kubernetes.Interface, error) {

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -230,6 +230,79 @@ Metrics are exposed at:
 
 ---
 
+## Model efficiency primitives (#40)
+
+### `aitra_model_tokens_total`
+
+**Type:** Counter  
+**Source:** Aggregation service  
+**Description:** Cumulative output tokens generated, by model series. Model-scoped complement to `aitra_namespace_tokens_total`.
+
+| Label | Description |
+|---|---|
+| `namespace` | Kubernetes namespace |
+| `model` | Model name |
+| `hardware` | GPU tier |
+| `workload` | Workload type |
+
+---
+
+### `aitra_model_energy_per_1m_tokens`
+
+**Type:** Gauge  
+**Source:** Aggregation service  
+**Description:** Joules per one million output tokens (`J/token × 1e6`) for the current window.
+
+| Label | Description |
+|---|---|
+| `namespace` | Kubernetes namespace |
+| `model` | Model name |
+| `hardware` | GPU tier |
+| `workload` | Workload type |
+
+---
+
+### `aitra_model_cost_per_1m_tokens_usd`
+
+**Type:** Gauge  
+**Source:** Aggregation service  
+**Description:** USD per million output tokens (energy cost), by model series. Same derivation as `aitra_cost_per_million_tokens_usd`. *Populated by the SiteConfig-cost follow-up to #40.*
+
+| Label | Description |
+|---|---|
+| `namespace` | Kubernetes namespace |
+| `model` | Model name |
+| `hardware` | GPU tier |
+| `workload` | Workload type |
+
+---
+
+### `aitra_tenant_cost_usd_total`
+
+**Type:** Counter  
+**Source:** Aggregation service  
+**Description:** Cumulative energy cost in USD attributed to a tenant, summed per measurement window. *Populated by the SiteConfig-cost follow-up to #40.*
+
+| Label | Description |
+|---|---|
+| `namespace` | Kubernetes namespace |
+| `team` | Team from pod annotation |
+| `cost_center` | Cost centre from pod annotation |
+
+---
+
+### `aitra_gpu_serving_utilization_ratio`
+
+**Type:** Gauge  
+**Source:** Aggregation service  
+**Description:** Fraction of elapsed time a node was executing inference requests: `(window − idle) / window`. Distinct from DCGM SM utilization. *Populated by the idle-tracking follow-up to #40.*
+
+| Label | Description |
+|---|---|
+| `node` | Kubernetes node name |
+
+---
+
 ## Example PromQL queries
 
 **Efficiency delta vs calibration baseline:**

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -266,7 +266,7 @@ Metrics are exposed at:
 
 **Type:** Gauge  
 **Source:** Aggregation service  
-**Description:** USD per million output tokens (energy cost), by model series. Same derivation as `aitra_cost_per_million_tokens_usd`. *Populated by the SiteConfig-cost follow-up to #40.*
+**Description:** USD per million output tokens (energy cost), by model series. Same derivation as `aitra_cost_per_million_tokens_usd`.
 
 | Label | Description |
 |---|---|
@@ -281,7 +281,7 @@ Metrics are exposed at:
 
 **Type:** Counter  
 **Source:** Aggregation service  
-**Description:** Cumulative energy cost in USD attributed to a tenant, summed per measurement window. *Populated by the SiteConfig-cost follow-up to #40.*
+**Description:** Cumulative energy cost in USD attributed to a tenant, summed per measurement window.
 
 | Label | Description |
 |---|---|
@@ -295,7 +295,7 @@ Metrics are exposed at:
 
 **Type:** Gauge  
 **Source:** Aggregation service  
-**Description:** Fraction of elapsed time a node was executing inference requests: `(window − idle) / window`. Distinct from DCGM SM utilization. *Populated by the idle-tracking follow-up to #40.*
+**Description:** Fraction of elapsed time a node was executing inference requests: `(window − idle) / window`. Distinct from DCGM SM utilization.
 
 | Label | Description |
 |---|---|

--- a/helm/aitra-meter/templates/aggregation-service.yaml
+++ b/helm/aitra-meter/templates/aggregation-service.yaml
@@ -36,6 +36,13 @@ spec:
               value: sqlite
             - name: SQLITE_PATH
               value: {{ .Values.storage.config.path | default "/data/aitra.db" | quote }}
+            # Site cost/carbon factors for cost + carbon metric derivation (issue #40).
+            - name: ELECTRICITY_COST_PER_KWH
+              value: {{ .Values.siteConfig.electricityCostPerKwh | quote }}
+            - name: GRID_GCO2_PER_KWH
+              value: {{ .Values.siteConfig.carbonIntensityFallback | quote }}
+            - name: CARBON_SOURCE
+              value: {{ .Values.siteConfig.carbonSource | quote }}
           ports:
             - name: metrics
               containerPort: {{ .Values.aggregationService.port }}

--- a/internal/aggregation/loop.go
+++ b/internal/aggregation/loop.go
@@ -129,6 +129,14 @@ func (l *Loop) ReportWindow(
 	metrics.NamespaceTokensTotal.WithLabelValues(attr.Namespace).
 		Add(float64(w.OutputTokens))
 
+	// Model-level efficiency primitives (issue #40). The cost/tenant/serving
+	// metrics in the same family are populated by the SiteConfig-cost and
+	// idle-tracking follow-up.
+	metrics.ModelTokensTotal.WithLabelValues(attr.Namespace, w.ModelName, hw, attr.Workload).
+		Add(float64(w.OutputTokens))
+	metrics.ModelEnergyPer1MTokens.WithLabelValues(attr.Namespace, w.ModelName, hw, attr.Workload).
+		Set(jpt * 1e6)
+
 	metrics.MeasurementCV.WithLabelValues(w.Node, w.ModelName).Set(cvVal)
 	stableF := 0.0
 	if stable {

--- a/internal/aggregation/loop.go
+++ b/internal/aggregation/loop.go
@@ -39,8 +39,11 @@ type Loop struct {
 	hardware    NodeHardware
 	writer      storage.RecordWriter
 
-	mu      sync.Mutex
-	cvByKey map[string]*CVTracker // key: node+"\x00"+modelName
+	site SiteParams
+
+	mu            sync.Mutex
+	cvByKey       map[string]*CVTracker      // key: node+"\x00"+modelName
+	servingByNode map[string]*servingTracker // key: node
 
 	// OTLPExporter is optional. When non-nil, each window is also emitted
 	// via OTLP to an OpenTelemetry Collector.
@@ -54,27 +57,44 @@ func NewLoop(
 	cal *CalibrationTable,
 	hw NodeHardware,
 	writer storage.RecordWriter,
+	site SiteParams,
 ) *Loop {
 	return &Loop{
-		cluster:     cluster,
-		resolver:    resolver,
-		calibration: cal,
-		hardware:    hw,
-		writer:      writer,
-		cvByKey:     make(map[string]*CVTracker),
+		cluster:       cluster,
+		resolver:      resolver,
+		calibration:   cal,
+		hardware:      hw,
+		writer:        writer,
+		site:          site,
+		cvByKey:       make(map[string]*CVTracker),
+		servingByNode: make(map[string]*servingTracker),
 	}
 }
 
 // ReportWindow implements measurementv1.MeasurementServiceServer.
 // It accepts a window report, computes J/token, and writes metrics + record.
-// Windows with zero output tokens are rejected (accepted=false); all others
-// are accepted even when flagged unstable — the unstable flag is recorded
-// in the storage record and in the Prometheus CV gauge.
+// Zero-output-token (idle) windows are not aggregated (accepted=false) but still
+// update the per-node idle-power and serving-utilization metrics. Serving windows
+// are accepted even when flagged unstable — the unstable flag is recorded in the
+// storage record and the Prometheus CV gauge.
 func (l *Loop) ReportWindow(
 	ctx context.Context,
 	w *measurementv1.WindowReport,
 ) (*measurementv1.WindowAck, error) {
-	if w.OutputTokens == 0 {
+	// --- serving / idle tracking (every window, issue #40) -----------------
+	// Update the per-node serving ratio for both serving and idle windows so the
+	// serving-utilization and idle-time ratios reflect recent activity.
+	servingWindow := w.OutputTokens > 0
+	servingRatio := l.recordServing(w.Node, servingWindow)
+	metrics.GPUServingUtilizationRatio.WithLabelValues(w.Node).Set(servingRatio)
+	metrics.IdleTimeRatio.WithLabelValues(w.Node).Set(1 - servingRatio)
+
+	// Idle window: record idle power and stop. Idle windows are not counted in
+	// J/token; the agent sends them so idle power/time stays visible.
+	if !servingWindow {
+		if w.PowerWatts > 0 {
+			metrics.IdlePowerWatts.WithLabelValues(w.Node).Set(w.PowerWatts)
+		}
 		return &measurementv1.WindowAck{Accepted: false}, nil
 	}
 
@@ -137,6 +157,9 @@ func (l *Loop) ReportWindow(
 	metrics.ModelEnergyPer1MTokens.WithLabelValues(attr.Namespace, w.ModelName, hw, attr.Workload).
 		Set(jpt * 1e6)
 
+	// Cost + carbon derivation (issue #40). No-op until a site is configured.
+	l.observeCostCarbon(attr, w, hw, jpt)
+
 	metrics.MeasurementCV.WithLabelValues(w.Node, w.ModelName).Set(cvVal)
 	stableF := 0.0
 	if stable {
@@ -195,4 +218,44 @@ func (l *Loop) ReportWindow(
 	}
 
 	return &measurementv1.WindowAck{Accepted: true}, nil
+}
+
+// joulesPerKWh is the number of joules in one kilowatt-hour.
+const joulesPerKWh = 3_600_000.0
+
+// recordServing updates the node's serving ring with one window and returns the
+// serving fraction (0.0–1.0) over the recent window history.
+func (l *Loop) recordServing(node string, serving bool) float64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	t, ok := l.servingByNode[node]
+	if !ok {
+		t = newServingTracker(DefaultServingWindowSize)
+		l.servingByNode[node] = t
+	}
+	return t.add(serving)
+}
+
+// observeCostCarbon derives the cost and carbon metrics for a serving window.
+// A factor left at zero disables its derivation, so the metric stays absent until
+// the site is configured. Cost per 1M tokens and carbon per token convert J→kWh
+// via joulesPerKWh; the tenant counter accrues this window's absolute energy cost.
+func (l *Loop) observeCostCarbon(attr Attribution, w *measurementv1.WindowReport, hw string, jpt float64) {
+	if l.site.ElectricityCostPerKWh > 0 {
+		costPerM := jpt / joulesPerKWh * l.site.ElectricityCostPerKWh * 1e6
+		metrics.CostPerMillionTokensUSD.WithLabelValues(
+			attr.Namespace, attr.Workload, w.ModelName, hw, l.site.costSourceLabel(),
+		).Set(costPerM)
+		metrics.ModelCostPer1MTokensUSD.WithLabelValues(
+			attr.Namespace, w.ModelName, hw, attr.Workload,
+		).Set(costPerM)
+		metrics.TenantCostUSDTotal.WithLabelValues(
+			attr.Namespace, attr.Team, attr.CostCentre,
+		).Add(w.EnergyJoules / joulesPerKWh * l.site.ElectricityCostPerKWh)
+	}
+	if l.site.GridGCO2PerKWh > 0 {
+		metrics.CO2PerTokenGrams.WithLabelValues(
+			attr.Namespace, attr.Workload, w.ModelName, hw, l.site.carbonSourceLabel(),
+		).Set(jpt / joulesPerKWh * l.site.GridGCO2PerKWh)
+	}
 }

--- a/internal/aggregation/loop_test.go
+++ b/internal/aggregation/loop_test.go
@@ -67,11 +67,15 @@ func (h *staticHardware) Hardware(_ context.Context, _ string) string { return h
 // --- helpers ----------------------------------------------------------------
 
 func newTestLoop(pods map[string]PodMeta, policy PolicyConfig, calEntries map[CalibrationKey]CalibrationEntry) (*Loop, *recordSink) {
+	return newTestLoopWithSite(pods, policy, calEntries, SiteParams{})
+}
+
+func newTestLoopWithSite(pods map[string]PodMeta, policy PolicyConfig, calEntries map[CalibrationKey]CalibrationEntry, site SiteParams) (*Loop, *recordSink) {
 	sink := &recordSink{}
 	resolver := NewResolver(&stubLookup{pods: pods}, policy)
 	cal := NewCalibrationTableFromMap(calEntries)
 	hw := &staticHardware{label: "h100"}
-	return NewLoop("test-cluster", resolver, cal, hw, sink), sink
+	return NewLoop("test-cluster", resolver, cal, hw, sink, site), sink
 }
 
 func baseReport() *measurementv1.WindowReport {
@@ -158,6 +162,88 @@ func TestLoopModelEnergyPer1MTokens(t *testing.T) {
 	want := (412.4 / 1328.0) * 1e6
 	if math.Abs(got-want) > 1e-3 {
 		t.Errorf("model_energy_per_1m_tokens = %v, want %v", got, want)
+	}
+}
+
+// TestLoopCostCarbonDerivation checks the cost + carbon metrics derive from
+// J/token and the configured site factors (issue #40 PR-2).
+func TestLoopCostCarbonDerivation(t *testing.T) {
+	const model = "cost-model"
+	site := SiteParams{ElectricityCostPerKWh: 0.12, GridGCO2PerKWh: 400}
+	loop, _ := newTestLoopWithSite(
+		map[string]PodMeta{"node-1/" + model: {Namespace: "prod", Workload: "chat", Team: "platform", CostCentre: "cc-1"}},
+		PolicyConfig{DefaultMethod: AttributionDirect}, nil, site,
+	)
+	tenant := metrics.TenantCostUSDTotal.WithLabelValues("prod", "platform", "cc-1")
+	before := testutil.ToFloat64(tenant)
+	w := baseReport()
+	w.ModelName = model
+	if _, err := loop.ReportWindow(context.Background(), w); err != nil {
+		t.Fatalf("ReportWindow: %v", err)
+	}
+
+	jpt := 412.4 / 1328.0
+	wantCostPerM := jpt / 3_600_000.0 * 0.12 * 1e6
+	if got := testutil.ToFloat64(metrics.CostPerMillionTokensUSD.WithLabelValues("prod", "chat", model, "h100", "manual")); math.Abs(got-wantCostPerM) > 1e-9 {
+		t.Errorf("cost_per_million = %v, want %v", got, wantCostPerM)
+	}
+	if got := testutil.ToFloat64(metrics.ModelCostPer1MTokensUSD.WithLabelValues("prod", model, "h100", "chat")); math.Abs(got-wantCostPerM) > 1e-9 {
+		t.Errorf("model_cost_per_1m = %v, want %v", got, wantCostPerM)
+	}
+	wantCO2 := jpt / 3_600_000.0 * 400
+	if got := testutil.ToFloat64(metrics.CO2PerTokenGrams.WithLabelValues("prod", "chat", model, "h100", "manual")); math.Abs(got-wantCO2) > 1e-12 {
+		t.Errorf("co2_per_token = %v, want %v", got, wantCO2)
+	}
+	wantTenantDelta := 412.4 / 3_600_000.0 * 0.12
+	if got := testutil.ToFloat64(tenant) - before; math.Abs(got-wantTenantDelta) > 1e-12 {
+		t.Errorf("tenant_cost delta = %v, want %v", got, wantTenantDelta)
+	}
+}
+
+// TestLoopCostDisabledWhenUnset checks cost metrics stay unset without site config.
+func TestLoopCostDisabledWhenUnset(t *testing.T) {
+	const model = "no-cost-model"
+	loop, _ := newTestLoop(
+		map[string]PodMeta{"node-1/" + model: {Namespace: "prod", Workload: "chat"}},
+		PolicyConfig{DefaultMethod: AttributionDirect}, nil,
+	)
+	w := baseReport()
+	w.ModelName = model
+	if _, err := loop.ReportWindow(context.Background(), w); err != nil {
+		t.Fatalf("ReportWindow: %v", err)
+	}
+	if got := testutil.ToFloat64(metrics.ModelCostPer1MTokensUSD.WithLabelValues("prod", model, "h100", "chat")); got != 0 {
+		t.Errorf("model_cost set to %v with no site config, want 0 (unset)", got)
+	}
+}
+
+// TestLoopIdleWindowTracking checks idle (zero-token) windows are not aggregated
+// but do drive idle power and the serving/idle ratios (issue #40 PR-2).
+func TestLoopIdleWindowTracking(t *testing.T) {
+	const node = "idle-node"
+	loop, sink := newTestLoop(map[string]PodMeta{}, PolicyConfig{}, nil)
+	w := baseReport()
+	w.Node = node
+	w.OutputTokens = 0 // idle
+	w.PowerWatts = 95.0
+	ack, err := loop.ReportWindow(context.Background(), w)
+	if err != nil {
+		t.Fatalf("ReportWindow: %v", err)
+	}
+	if ack.Accepted {
+		t.Error("idle window Accepted = true, want false")
+	}
+	if sink.len() != 0 {
+		t.Errorf("idle window wrote %d records, want 0", sink.len())
+	}
+	if got := testutil.ToFloat64(metrics.IdlePowerWatts.WithLabelValues(node)); got != 95.0 {
+		t.Errorf("idle_power_watts = %v, want 95", got)
+	}
+	if got := testutil.ToFloat64(metrics.GPUServingUtilizationRatio.WithLabelValues(node)); got != 0 {
+		t.Errorf("serving_ratio = %v, want 0 after one idle window", got)
+	}
+	if got := testutil.ToFloat64(metrics.IdleTimeRatio.WithLabelValues(node)); got != 1 {
+		t.Errorf("idle_time_ratio = %v, want 1 after one idle window", got)
 	}
 }
 

--- a/internal/aggregation/loop_test.go
+++ b/internal/aggregation/loop_test.go
@@ -6,7 +6,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	measurementv1 "github.com/aitra-ai/aitra-meter/api/proto/measurement/v1"
+	"github.com/aitra-ai/aitra-meter/internal/metrics"
 )
 
 // --- stubs ------------------------------------------------------------------
@@ -113,6 +116,51 @@ func TestLoopJPerTokenArithmetic(t *testing.T) {
 	}
 }
 
+// TestLoopModelTokensTotalAccumulates checks the model-level token counter is
+// monotonic across windows. A unique model label isolates this counter child
+// from other tests (Prometheus counters are process-global and never reset).
+func TestLoopModelTokensTotalAccumulates(t *testing.T) {
+	const model = "tokens-accum-model"
+	loop, _ := newTestLoop(
+		map[string]PodMeta{"node-1/" + model: {Namespace: "prod", Workload: "chat"}},
+		PolicyConfig{DefaultMethod: AttributionDirect},
+		nil,
+	)
+	child := metrics.ModelTokensTotal.WithLabelValues("prod", model, "h100", "chat")
+	before := testutil.ToFloat64(child)
+	for i := 0; i < 3; i++ {
+		w := baseReport()
+		w.ModelName = model
+		if _, err := loop.ReportWindow(context.Background(), w); err != nil {
+			t.Fatalf("ReportWindow: %v", err)
+		}
+	}
+	if got, want := testutil.ToFloat64(child)-before, 3.0*1328.0; got != want {
+		t.Errorf("model_tokens_total delta = %v, want %v", got, want)
+	}
+}
+
+// TestLoopModelEnergyPer1MTokens checks the J/1M-tokens gauge reflects the
+// current window's J/token scaled to one million tokens.
+func TestLoopModelEnergyPer1MTokens(t *testing.T) {
+	const model = "energy1m-model"
+	loop, _ := newTestLoop(
+		map[string]PodMeta{"node-1/" + model: {Namespace: "prod", Workload: "chat"}},
+		PolicyConfig{DefaultMethod: AttributionDirect},
+		nil,
+	)
+	w := baseReport()
+	w.ModelName = model
+	if _, err := loop.ReportWindow(context.Background(), w); err != nil {
+		t.Fatalf("ReportWindow: %v", err)
+	}
+	got := testutil.ToFloat64(metrics.ModelEnergyPer1MTokens.WithLabelValues("prod", model, "h100", "chat"))
+	want := (412.4 / 1328.0) * 1e6
+	if math.Abs(got-want) > 1e-3 {
+		t.Errorf("model_energy_per_1m_tokens = %v, want %v", got, want)
+	}
+}
+
 func TestLoopZeroTokensRejected(t *testing.T) {
 	loop, sink := newTestLoop(nil, PolicyConfig{}, nil)
 	w := baseReport()
@@ -131,16 +179,16 @@ func TestLoopZeroTokensRejected(t *testing.T) {
 
 func TestLoopAttributionMethod(t *testing.T) {
 	tests := []struct {
-		name    string
-		ns      string
-		policy  PolicyConfig
-		wantM   AttributionMethod
+		name   string
+		ns     string
+		policy PolicyConfig
+		wantM  AttributionMethod
 	}{
 		{
-			name:  "direct",
-			ns:    "prod",
+			name:   "direct",
+			ns:     "prod",
 			policy: PolicyConfig{DefaultMethod: AttributionDirect},
-			wantM: AttributionDirect,
+			wantM:  AttributionDirect,
 		},
 		{
 			name: "proportional override",

--- a/internal/aggregation/serving.go
+++ b/internal/aggregation/serving.go
@@ -1,0 +1,40 @@
+package aggregation
+
+// DefaultServingWindowSize is the number of recent windows used for the
+// serving-utilization and idle-time ratios. At the default 30s measurement
+// window this spans ~1 hour, matching the aitra_idle_time_ratio definition.
+const DefaultServingWindowSize = 120
+
+// servingTracker is a fixed-size ring over the most recent windows for one node,
+// recording whether each window was serving (output tokens > 0) or idle. It
+// yields the serving fraction across the ring in O(1) per update.
+type servingTracker struct {
+	ring    []bool
+	idx     int // next slot to write
+	count   int // filled slots (<= len(ring))
+	serving int // serving slots currently in the ring
+}
+
+func newServingTracker(size int) *servingTracker {
+	if size <= 0 {
+		size = DefaultServingWindowSize
+	}
+	return &servingTracker{ring: make([]bool, size)}
+}
+
+// add records one window and returns the serving fraction over the ring (0.0–1.0).
+func (s *servingTracker) add(serving bool) float64 {
+	if s.count == len(s.ring) {
+		if s.ring[s.idx] { // evicting a serving slot
+			s.serving--
+		}
+	} else {
+		s.count++
+	}
+	s.ring[s.idx] = serving
+	if serving {
+		s.serving++
+	}
+	s.idx = (s.idx + 1) % len(s.ring)
+	return float64(s.serving) / float64(s.count)
+}

--- a/internal/aggregation/site.go
+++ b/internal/aggregation/site.go
@@ -1,0 +1,27 @@
+package aggregation
+
+// SiteParams carries the per-site conversion factors the aggregation loop uses to
+// derive cost and carbon from J/token. They come from the aggregation-service
+// configuration (Helm `siteConfig`). A zero ElectricityCostPerKWh or
+// GridGCO2PerKWh disables the corresponding derivation, so the cost/carbon
+// metrics are simply not set until a site is configured.
+type SiteParams struct {
+	ElectricityCostPerKWh float64 // USD per kWh
+	GridGCO2PerKWh        float64 // grid carbon intensity, gCO2 per kWh
+	CarbonSource          string  // carbon_source metric label; defaults to "manual"
+	CostSource            string  // cost_source metric label; defaults to "manual"
+}
+
+func (s SiteParams) carbonSourceLabel() string {
+	if s.CarbonSource == "" {
+		return "manual"
+	}
+	return s.CarbonSource
+}
+
+func (s SiteParams) costSourceLabel() string {
+	if s.CostSource == "" {
+		return "manual"
+	}
+	return s.CostSource
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -29,7 +29,7 @@ var (
 	// CostPerMillionTokensUSD is $/M output tokens (energy cost only).
 	CostPerMillionTokensUSD = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "aitra_cost_per_million_tokens_usd",
-		Help: "USD per million output tokens (energy cost only). Derived: J/token * $/kWh / 3600 * 1e6.",
+		Help: "USD per million output tokens (energy cost only). Derived: J/token / 3.6e6 (kWh) * $/kWh * 1e6.",
 	}, []string{"namespace", "workload", "model", "hardware", "cost_source"})
 
 	// NamespaceEnergyJoulesTotal is cumulative energy per namespace.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -109,4 +109,45 @@ var (
 		Name: "aitra_gpu_utilization_efficiency",
 		Help: "Output tokens per second per GPU watt. Bridges GPU utilisation and token throughput.",
 	}, []string{"namespace", "workload", "model", "hardware"})
+
+	// --- Model-level efficiency primitives (issue #40) -----------------------
+	// The token + energy metrics are populated by the aggregation loop. The cost
+	// (model_cost, tenant_cost) and serving-ratio metrics are declared here to
+	// establish the family; they are populated by the SiteConfig-cost and
+	// idle-tracking follow-up (same dependency as aitra_cost_per_million_tokens_usd
+	// and aitra_idle_time_ratio).
+
+	// ModelTokensTotal is cumulative output tokens by model series.
+	ModelTokensTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aitra_model_tokens_total",
+		Help: "Cumulative output tokens generated, by model series.",
+	}, []string{"namespace", "model", "hardware", "workload"})
+
+	// ModelEnergyPer1MTokens is energy per one million output tokens (J/1M tokens).
+	ModelEnergyPer1MTokens = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_model_energy_per_1m_tokens",
+		Help: "Joules per one million output tokens (J/token x 1e6) for the current window.",
+	}, []string{"namespace", "model", "hardware", "workload"})
+
+	// ModelCostPer1MTokensUSD is per-model USD per million output tokens (energy
+	// cost). Populated by the SiteConfig-cost follow-up to #40.
+	ModelCostPer1MTokensUSD = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_model_cost_per_1m_tokens_usd",
+		Help: "USD per million output tokens (energy cost) by model series; same derivation as aitra_cost_per_million_tokens_usd.",
+	}, []string{"namespace", "model", "hardware", "workload"})
+
+	// TenantCostUSDTotal is cumulative energy cost (USD) attributed to a tenant.
+	// Populated by the SiteConfig-cost follow-up to #40.
+	TenantCostUSDTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aitra_tenant_cost_usd_total",
+		Help: "Cumulative energy cost in USD attributed to a tenant, summed per measurement window.",
+	}, []string{"namespace", "team", "cost_center"})
+
+	// GPUServingUtilizationRatio is the fraction of elapsed time a node was
+	// serving inference requests: (window - idle) / window. Distinct from DCGM SM
+	// utilization. Populated by the idle-tracking follow-up to #40.
+	GPUServingUtilizationRatio = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_gpu_serving_utilization_ratio",
+		Help: "Fraction of elapsed time the node was serving inference requests (0.0-1.0).",
+	}, []string{"node"})
 )


### PR DESCRIPTION
Part of #40 — first of two PRs (the metrics that need no new plumbing).

Establishes the model-level **AI efficiency metric family** in `internal/metrics` and populates the two metrics derivable from data the aggregation loop already holds.

### Populated now (in the aggregation loop)
| Metric | Type | Meaning · labels |
|---|---|---|
| `aitra_model_tokens_total` | Counter | Output tokens by model series · `namespace, model, hardware, workload` |
| `aitra_model_energy_per_1m_tokens` | Gauge | `J/token × 1e6` for the window · same labels |

### Declared now, populated in the follow-up (PR-2)
These need a **cost source** (`$/kWh` from SiteConfig) or **idle-time tracking** — the same dependency that currently gates the already-declared `aitra_cost_per_million_tokens_usd`, `aitra_co2_per_token_grams`, and `aitra_idle_time_ratio` (none populated yet).

| Metric | Type | Blocked on |
|---|---|---|
| `aitra_model_cost_per_1m_tokens_usd` | Gauge | SiteConfig cost wiring |
| `aitra_tenant_cost_usd_total` | Counter | SiteConfig cost wiring |
| `aitra_gpu_serving_utilization_ratio` | Gauge | idle-time tracking (loop currently drops zero-token windows) |

**PR-2** will wire SiteConfig cost into the aggregation loop (lighting these up **and** the existing cost/carbon metrics) and add idle-time tracking, then populate the three above.

### Tests
- `TestLoopModelTokensTotalAccumulates` — counter monotonicity across windows
- `TestLoopModelEnergyPer1MTokens` — gauge value (`J/token × 1e6`)

via `prometheus/client_golang/prometheus/testutil`.

### Docs
`docs/reference/metrics.md` updated with all five metrics (deferred ones flagged).

### Out of scope
Grafana panels land in PR-2 alongside the cost/serving metrics so the dashboard gets the full new-panel set at once. Prefill/decode + MIG remain deferred per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
