### PR TITLE
feat(alerting): cost-budget + TTFT alerts, runbooks, helm cost budgets (closes #46)

### DIFF
--- a/docs/guides/cost-budgets.md
+++ b/docs/guides/cost-budgets.md
@@ -1,0 +1,65 @@
+# Cost budgets
+
+Aitra Meter can page you when a namespace's inference-energy spend exceeds a
+budget you set. This guide covers the `costBudgets` Helm value and the
+`TenantCostBudgetExceeded` alert.
+
+## How it works
+
+1. You set a per-namespace 24-hour USD budget in the `costBudgets` Helm value.
+2. The chart renders one `aitra_tenant_cost_budget_usd_24h` **recording rule** per
+   entry (see `helm/aitra-meter/templates/prometheusrule.yaml`).
+3. The `TenantCostBudgetExceeded` alert (in `examples/alerting-rules.yaml`) compares
+   the namespace's actual 24h spend against that budget:
+
+   ```promql
+   increase(aitra_tenant_cost_usd_total[24h])
+     > on(namespace) group_left() aitra_tenant_cost_budget_usd_24h
+   ```
+
+Budgets live as a recording rule (not in code) so you can change them with a
+`helm upgrade` — no redeploy of the aggregation service.
+
+## Configure
+
+```yaml
+# values.yaml
+costBudgets:
+  inference-prod: 500   # USD per 24h
+  inference-fin: 250
+```
+
+```bash
+helm upgrade aitra-meter aitra/aitra-meter -f values.yaml
+kubectl get prometheusrule -n monitoring   # <release>-cost-budgets appears
+```
+
+Leave `costBudgets: {}` (default) to render no budget rules; the alert then stays
+inactive.
+
+## Dependency
+
+`TenantCostBudgetExceeded` reads `aitra_tenant_cost_usd_total`, which is populated
+once the SiteConfig cost wiring lands (the cost/idle follow-up to issue #40). Until
+then the metric is empty and the alert never fires — the budget recording rule is
+still rendered and harmless.
+
+## Relationship to `MeasurementPolicy.budget`
+
+These are two different mechanisms:
+
+| | `costBudgets` (this guide) | `MeasurementPolicy` `spec.budget` |
+|---|---|---|
+| Path | Prometheus recording rule + alert | In-product budget tracking (CRD) |
+| Window | 24 hours | Monthly |
+| Use | Alertmanager paging on spend | Policy-level budget configuration |
+
+Use `costBudgets` when you want Prometheus/Alertmanager to page on short-term
+overspend; use `MeasurementPolicy.budget` for the platform's own budget policy.
+
+## Verify the rules
+
+```bash
+promtool check rules examples/alerting-rules.yaml
+kubectl get prometheusrule -n monitoring <release>-cost-budgets -o yaml
+```

--- a/docs/runbooks/ai-efficiency-regression.md
+++ b/docs/runbooks/ai-efficiency-regression.md
@@ -1,0 +1,43 @@
+# Runbook: AIEfficiencyRegression
+
+**Alert:** `AIEfficiencyRegression` · **Severity:** warning
+
+## What it means
+
+A `workload × model × hardware` series is now burning **>20% more joules per output
+token** than its own 1-hour rolling average. Energy efficiency for that series has
+regressed.
+
+## Why it matters
+
+Higher J/token means higher energy cost and carbon per token for the same output —
+it shows up directly in chargeback and `aitra_cost_per_million_tokens_usd`.
+
+## Diagnose
+
+```promql
+# Current vs 1h baseline for the firing series
+aitra_j_per_token{namespace="...", model="...", hardware="..."}
+avg_over_time(aitra_j_per_token{...}[1h])
+```
+
+Common causes:
+- **Smaller effective batch size** — traffic dropped, so fixed GPU overhead is
+  amortized over fewer tokens. Cross-check `aitra_idle_time_ratio` and request rate.
+- **Thermal throttling** — check `aitra_gpu_power_watts` and node temperature.
+- **Model / vLLM config change** — precision, max-num-seqs, or tensor-parallel change.
+- **Noisy neighbor** — another workload sharing the node/GPU.
+
+## Remediate
+
+- If caused by low traffic: consolidate replicas or scale down (see the GPU-idle runbook).
+- If thermal: check cooling / power caps on the node.
+- If a config regression: compare against `aitra_calibration_reference_j_per_token`
+  and roll back the offending change.
+- If transient (traffic spike settling): the alert clears once the series returns
+  within 20% of its rolling average.
+
+## Related
+
+`aitra_j_per_token`, `aitra_calibration_reference_j_per_token`,
+`aitra_gpu_power_watts`, `aitra_idle_time_ratio`.

--- a/docs/runbooks/gpu-idle.md
+++ b/docs/runbooks/gpu-idle.md
@@ -1,0 +1,38 @@
+# Runbook: GPUIdleExcessive
+
+**Alert:** `GPUIdleExcessive` · **Severity:** warning
+
+## What it means
+
+A node has spent **>40% of the last hour with no active inference requests**
+(`aitra_idle_time_ratio > 0.40`) for 30 minutes. The GPU is powered and drawing
+energy but producing few or no tokens.
+
+## Why it matters
+
+Idle GPU time is pure cost and carbon with zero output. It is the single biggest
+lever for reducing $/token at the cluster level.
+
+## Diagnose
+
+```promql
+aitra_idle_time_ratio{node="..."}
+aitra_idle_power_watts{node="..."}          # watts wasted while idle
+```
+
+Common causes:
+- **Over-provisioned replicas** for current traffic.
+- **Uneven scheduling** — traffic concentrated on other nodes.
+- **A drained/cordoned workload** that left the GPU allocated but unused.
+
+## Remediate
+
+- Scale the inference Deployment down, or enable KEDA scale-to-zero on
+  `aitra_idle_time_ratio` (see `docs/guides/keda-integration.md`).
+- Consolidate low-traffic models onto fewer nodes.
+- If the node should be idle (batch/off-peak), silence the alert for that node or
+  raise the threshold for its label set.
+
+## Related
+
+`aitra_idle_time_ratio`, `aitra_idle_power_watts`, `aitra_gpu_serving_utilization_ratio`.

--- a/docs/runbooks/measurement-unstable.md
+++ b/docs/runbooks/measurement-unstable.md
@@ -1,0 +1,41 @@
+# Runbook: MeasurementUnstable
+
+**Alert:** `MeasurementUnstable` · **Severity:** warning
+
+## What it means
+
+The rolling coefficient of variation of J/token for a `node × model` series has
+been **above 3%** (`aitra_measurement_cv > 0.03`) for 5 minutes. Measurements are
+flagged unstable — not dropped, but chargeback/efficiency figures for this series
+may be unreliable.
+
+## Why it matters
+
+A high CV means the J/token signal is noisy, so derived cost and carbon for this
+series carry more uncertainty. Decisions (scaling, chargeback) should wait for the
+series to stabilize.
+
+## Diagnose
+
+```promql
+aitra_measurement_cv{node="...", model_name="..."}
+aitra_measurement_window_stable{node="...", model_name="..."}   # 0 = flagged
+```
+
+Common causes:
+- **Bursty / low traffic** — few tokens per window amplifies variance.
+- **Workload interference** — co-located pods competing for the GPU.
+- **Thermal throttling** — variable clocks → variable power.
+- **Very short windows** relative to request duration.
+
+## Remediate
+
+- For bursty traffic: increase the measurement window or CV window size
+  (`measurementAgent.cvWindowSize`) so more samples smooth the signal.
+- Reduce interference: isolate the model onto its own GPU, or check MIG slicing.
+- Check node thermals / power caps if throttling is suspected.
+- The alert clears automatically once CV falls back below the threshold.
+
+## Related
+
+`aitra_measurement_cv`, `aitra_measurement_window_stable`, `aitra_j_per_token`.

--- a/docs/runbooks/tenant-budget.md
+++ b/docs/runbooks/tenant-budget.md
@@ -1,0 +1,55 @@
+# Runbook: TenantCostBudgetExceeded
+
+**Alert:** `TenantCostBudgetExceeded` · **Severity:** warning
+
+## What it means
+
+A namespace's inference-energy spend over the **last 24 hours** has exceeded its
+configured budget:
+
+```promql
+increase(aitra_tenant_cost_usd_total[24h])
+  > on(namespace) group_left() aitra_tenant_cost_budget_usd_24h
+```
+
+The budget (`aitra_tenant_cost_budget_usd_24h`) comes from the chart `costBudgets`
+value — see [cost-budgets guide](../guides/cost-budgets.md).
+
+## Why it matters
+
+This is a spend SLO. It tells you a tenant is on track to overrun its allocation,
+before the monthly bill lands.
+
+## Diagnose
+
+```promql
+increase(aitra_tenant_cost_usd_total{namespace="..."}[24h])   # actual 24h spend
+aitra_tenant_cost_budget_usd_24h{namespace="..."}             # configured budget
+# What is driving the spend?
+topk(5, increase(aitra_model_tokens_total{namespace="..."}[24h]))
+aitra_j_per_token{namespace="..."}
+```
+
+Common causes:
+- **Traffic growth** — legitimately more tokens served.
+- **Efficiency regression** — J/token up (see the efficiency-regression runbook).
+- **Idle waste** — paying for idle GPUs (see the GPU-idle runbook).
+- **Budget set too low** for the workload's real footprint.
+
+## Remediate
+
+- If demand is legitimate: raise the budget in `costBudgets` and `helm upgrade`.
+- If efficiency/idle driven: act on the corresponding runbook to cut J/token or
+  idle time rather than just raising the budget.
+- If chronic: move the workload to more efficient hardware (compare
+  `aitra_model_energy_per_1m_tokens` across `hardware`).
+
+## Note on data dependency
+
+This alert needs `aitra_tenant_cost_usd_total`, populated once the SiteConfig cost
+wiring lands (issue #40 follow-up). Until then it cannot fire.
+
+## Related
+
+`aitra_tenant_cost_usd_total`, `aitra_tenant_cost_budget_usd_24h`,
+`aitra_model_tokens_total`, `aitra_model_energy_per_1m_tokens`.

--- a/docs/runbooks/ttft-regression.md
+++ b/docs/runbooks/ttft-regression.md
@@ -1,0 +1,43 @@
+# Runbook: TTFTRegression
+
+**Alert:** `TTFTRegression` · **Severity:** warning
+
+## What it means
+
+The **P95 time-to-first-token has exceeded 3 seconds** over the last 5 minutes for
+a namespace. This is a latency SLO signal sourced directly from vLLM
+(`vllm:time_to_first_token_seconds`) — Aitra Meter ships the rule but does not own
+or re-export the metric.
+
+## Why it matters
+
+TTFT is the latency users feel first. A regression usually means the serving tier
+is saturated or queueing, which also tends to drag efficiency (J/token) and may
+precede dropped requests.
+
+## Diagnose
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, namespace) (rate(vllm:time_to_first_token_seconds_bucket[5m]))) 
+vllm:num_requests_running                 # queue depth / concurrency
+vllm:num_requests_waiting
+```
+
+Common causes:
+- **Saturation** — request rate above capacity; requests queueing.
+- **Long prompts** — prefill cost up (large input tokens).
+- **KV-cache pressure** — high `gpu_cache_usage_perc`, preemptions.
+- **Co-located noisy neighbor** on the GPU/node.
+
+## Remediate
+
+- Scale the inference Deployment out, or enable autoscaling on queue depth.
+- Tune vLLM (`max-num-seqs`, `max-num-batched-tokens`) for the prompt profile.
+- Route long-prompt workloads to dedicated replicas.
+- If 3s is too strict/loose for this namespace, adjust the alert threshold.
+
+## Related
+
+`vllm:time_to_first_token_seconds_bucket`, `vllm:num_requests_running`,
+`aitra_j_per_token` (efficiency often regresses alongside latency).

--- a/examples/alerting-rules.yaml
+++ b/examples/alerting-rules.yaml
@@ -1,6 +1,12 @@
 # Aitra Meter — reference Prometheus alerting rules.
 # Apply with: kubectl apply -f examples/alerting-rules.yaml
 # Or mount via the Prometheus Operator PrometheusRule CRD.
+#
+# TenantCostBudgetExceeded compares 24h tenant cost against a per-namespace
+# budget exposed as aitra_tenant_cost_budget_usd_24h. The Helm chart renders that
+# recording rule from the `costBudgets` value — see docs/guides/cost-budgets.md.
+# It also reads aitra_tenant_cost_usd_total, populated once the SiteConfig cost
+# wiring lands (issue #40 follow-up); until then the alert stays inactive.
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -27,6 +33,7 @@ spec:
             description: >
               {{ $labels.namespace }}/{{ $labels.model }} on {{ $labels.hardware }}:
               J/token is {{ $value | humanize }} — more than 20% above the 1h average.
+            runbook_url: "https://github.com/aitra-ai/aitra-meter/blob/main/docs/runbooks/ai-efficiency-regression.md"
 
         - alert: GPUIdleExcessive
           expr: aitra_idle_time_ratio > 0.40
@@ -38,6 +45,7 @@ spec:
             description: >
               Node {{ $labels.node }} has been idle {{ $value | humanizePercentage }}
               of the last hour. Consider scaling down or consolidating workloads.
+            runbook_url: "https://github.com/aitra-ai/aitra-meter/blob/main/docs/runbooks/gpu-idle.md"
 
         - alert: MeasurementUnstable
           expr: aitra_measurement_cv > 0.03
@@ -50,3 +58,38 @@ spec:
               Node {{ $labels.node }}, model {{ $labels.model_name }}:
               CV is {{ $value | humanizePercentage }}. Check for workload
               interference or GPU thermal throttling.
+            runbook_url: "https://github.com/aitra-ai/aitra-meter/blob/main/docs/runbooks/measurement-unstable.md"
+
+        - alert: TTFTRegression
+          expr: |
+            histogram_quantile(0.95,
+              sum by (le, namespace) (
+                rate(vllm:time_to_first_token_seconds_bucket[5m])
+              )
+            ) > 3.0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "P95 time-to-first-token >3s"
+            description: >
+              Namespace {{ $labels.namespace }}: P95 TTFT is {{ $value | humanize }}s
+              over the last 5m. Sourced directly from vLLM
+              (vllm:time_to_first_token_seconds) — Aitra ships the rule, not the metric.
+            runbook_url: "https://github.com/aitra-ai/aitra-meter/blob/main/docs/runbooks/ttft-regression.md"
+
+        - alert: TenantCostBudgetExceeded
+          expr: |
+            increase(aitra_tenant_cost_usd_total[24h])
+            > on(namespace) group_left()
+            aitra_tenant_cost_budget_usd_24h
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Namespace {{ $labels.namespace }} exceeded its 24h cost budget"
+            description: >
+              {{ $labels.namespace }} spent {{ $value | humanize }} USD on inference
+              energy in the last 24h — over its configured budget. Set budgets via the
+              chart `costBudgets` value (docs/guides/cost-budgets.md).
+            runbook_url: "https://github.com/aitra-ai/aitra-meter/blob/main/docs/runbooks/tenant-budget.md"

--- a/helm/aitra-meter/templates/prometheusrule.yaml
+++ b/helm/aitra-meter/templates/prometheusrule.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.costBudgets }}
+---
+# Per-namespace 24h inference-energy cost budgets, rendered from .Values.costBudgets.
+# Exposes aitra_tenant_cost_budget_usd_24h{namespace} as a recording rule, which the
+# TenantCostBudgetExceeded alert (examples/alerting-rules.yaml) compares against.
+# See docs/guides/cost-budgets.md.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "aitra-meter.fullname" . }}-cost-budgets
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  labels:
+    {{- include "aitra-meter.labels" . | nindent 4 }}
+    role: alert-rules
+spec:
+  groups:
+    - name: aitra-meter-cost-budgets
+      rules:
+        {{- range $namespace, $budget := .Values.costBudgets }}
+        - record: aitra_tenant_cost_budget_usd_24h
+          expr: "{{ $budget }}"
+          labels:
+            namespace: {{ $namespace | quote }}
+        {{- end }}
+{{- end }}

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -115,6 +115,16 @@ siteConfig:
   carbonIntensityFallback: 400
   carbonSource: electricitymaps
 
+# Per-namespace 24h inference-energy cost budgets (USD), keyed by namespace name.
+# Each entry renders an aitra_tenant_cost_budget_usd_24h recording rule (see
+# templates/prometheusrule.yaml) that the TenantCostBudgetExceeded alert compares
+# against. Empty = no budget rules rendered. See docs/guides/cost-budgets.md.
+# Example:
+#   costBudgets:
+#     inference-prod: 500
+#     inference-fin: 250
+costBudgets: {}
+
 # External API credentials
 externalApis:
   electricityMaps:


### PR DESCRIPTION
Closes #46.

Extends the reference alerting rules with the cost/latency SLO alerts operators actually page on, plus a runbook per alert and a Helm-driven budget mechanism.

### Alerts (`examples/alerting-rules.yaml`)
| Alert | Fires when |
|---|---|
| `TenantCostBudgetExceeded` (new) | namespace 24h energy spend > its budget |
| `TTFTRegression` (new) | P95 vLLM TTFT > 3s (sourced from vLLM, not re-exposed by Aitra) |
| `AIEfficiencyRegression` / `GPUIdleExcessive` / `MeasurementUnstable` | existing |

All five now carry a `runbook_url` annotation.

### Helm budget mechanism
The `costBudgets` value → `templates/prometheusrule.yaml` renders one `aitra_tenant_cost_budget_usd_24h` recording rule per namespace, which `TenantCostBudgetExceeded` compares against. Default `{}` renders nothing.

```yaml
costBudgets:
  inference-prod: 500
  inference-fin: 250
```

### Docs
- `docs/guides/cost-budgets.md` — mechanism, configuration, dependency, relationship to `MeasurementPolicy.budget`
- `docs/runbooks/*.md` — one runbook per alert (symptom → impact → diagnose → remediate)

### Notes / dependencies
- `TenantCostBudgetExceeded` reads `aitra_tenant_cost_usd_total`, populated by the SiteConfig cost wiring (follow-up to #40). The alert + recording rule ship now and stay inert until that metric carries data.
- Rules validated by YAML parse; `promtool check rules` runs in CI (promtool not available in my local env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
