### PR TITLE
feat(energy): add DCGM EnergyProvider reading dcgm-exporter

### DIFF
--- a/cmd/measurement-agent/main.go
+++ b/cmd/measurement-agent/main.go
@@ -15,13 +15,14 @@ import (
 
 	// Import providers to trigger their init() registration.
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/amd"
+	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/dcgm"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/zeus"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/genericprometheus"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/vllm"
 )
 
 func main() {
-	energyType := flag.String("energy-provider", "nvml", "Energy provider: nvml | amd")
+	energyType := flag.String("energy-provider", "nvml", "Energy provider: nvml | amd | zeus | dcgm")
 	inferenceType := flag.String("inference-provider", "vllm", "Inference provider: vllm | generic-prometheus")
 	aggregatorAddr := flag.String("aggregator", "aitra-meter-aggregation:9091", "Aggregation service gRPC address")
 	nodeName := flag.String("node", "", "Kubernetes node name (defaults to NODE_NAME env var)")

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -6,8 +6,8 @@
 |---|---|---|---|
 | NVML | `nvml` | NVIDIA GPUs — H100, H200, L40S, A100, B200 | Default. Pure Go. No sidecar. |
 | AMD | `amd` | AMD GPUs — MI300X, MI250X, MI210, ROCm 6.x+ | Via libamd_smi.so. No sidecar. |
+| DCGM | `dcgm` | NVIDIA GPUs | Scrapes a node-local dcgm-exporter Prometheus endpoint. Pure Go, no sidecar. Resolution bounded by the exporter scrape interval. |
 | Zeus | `zeus` (community) | NVIDIA + AMD + CPU/DRAM + Apple Silicon + Jetson | Requires zeusd sidecar. Use when NVML/AMD access is restricted or CPU+DRAM energy is needed alongside GPU. |
-| DCGM | `dcgm` (community) | NVIDIA GPUs | NVIDIA-proprietary. Richer GPU telemetry. |
 
 ## Inference providers
 
@@ -73,11 +73,11 @@ measurementAgent:
 
 | GPU | Supported | Energy provider |
 |---|---|---|
-| NVIDIA H100 SXM5 | Yes | nvml, zeus |
-| NVIDIA H200 SXM | Yes | nvml, zeus |
-| NVIDIA L40S | Yes | nvml, zeus |
-| NVIDIA B200 | Yes | nvml, zeus |
-| NVIDIA A100 | Yes | nvml, zeus |
+| NVIDIA H100 SXM5 | Yes | nvml, zeus, dcgm |
+| NVIDIA H200 SXM | Yes | nvml, zeus, dcgm |
+| NVIDIA L40S | Yes | nvml, zeus, dcgm |
+| NVIDIA B200 | Yes | nvml, zeus, dcgm |
+| NVIDIA A100 | Yes | nvml, zeus, dcgm |
 | AMD MI300X | Yes | amd, zeus |
 | AMD MI250X | Yes | amd, zeus |
 | Apple Silicon (M-series) | Community (zeus only) | zeus |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,7 +24,7 @@ Complete reference for all Helm values, CRD fields, and pod annotations.
 | `measurementAgent.resources.requests.memory` | string | `128Mi` | Memory request |
 | `measurementAgent.resources.limits.cpu` | string | `500m` | CPU limit |
 | `measurementAgent.resources.limits.memory` | string | `256Mi` | Memory limit |
-| `measurementAgent.energyProvider.type` | string | `nvml` | Energy provider name. Built-in: `nvml`, `amd`. Community: `zeus` |
+| `measurementAgent.energyProvider.type` | string | `nvml` | Energy provider name. Built-in: `nvml`, `amd`, `dcgm`. Community: `zeus` |
 | `measurementAgent.energyProvider.config` | map | `{}` | Provider-specific config key-value pairs |
 | `measurementAgent.inferenceProvider.type` | string | `vllm` | Inference provider name. Built-in: `vllm`, `generic-prometheus` |
 | `measurementAgent.inferenceProvider.config.endpoint` | string | `http://localhost:8000/metrics` | Inference server metrics endpoint |

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -39,6 +39,11 @@ measurementAgent:
   energyProvider:
     type: nvml
     config: {}
+  # dcgm example (scrape a node-local dcgm-exporter instead of reading NVML in-process):
+  # energyProvider:
+  #   type: dcgm
+  #   config:
+  #     endpoint: "http://localhost:9400/metrics"
   inferenceProvider:
     type: vllm
     config:

--- a/internal/provider/energy/dcgm/dcgm.go
+++ b/internal/provider/energy/dcgm/dcgm.go
@@ -1,0 +1,250 @@
+// Package dcgm provides an EnergyProvider that reads NVIDIA GPU energy from a
+// node-local dcgm-exporter Prometheus endpoint. It suits enterprise clusters
+// that already run dcgm-exporter (e.g. via the GPU Operator), alongside or
+// instead of the in-process nvml provider.
+//
+// Energy comes from DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, a cumulative per-GPU
+// counter in millijoules: BeginWindow snapshots it and EndWindow returns the
+// joules consumed in between, summed across every GPU on the node. Idle power is
+// the sum of DCGM_FI_DEV_POWER_USAGE (watts) across GPUs.
+//
+// Because it scrapes an HTTP endpoint rather than calling the driver directly,
+// resolution is bounded by the dcgm-exporter collection interval; for the
+// tightest window alignment prefer the nvml provider. This package is pure Go
+// with no CGO or Python dependency and runs on any platform.
+//
+// Config keys (energyProvider.config in values.yaml):
+//
+//	endpoint       dcgm-exporter metrics URL (default http://localhost:9400/metrics)
+//	energy-metric  override the energy counter name
+//	power-metric   override the power gauge name
+package dcgm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+const (
+	defaultEndpoint = "http://localhost:9400/metrics"
+	// DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION is a cumulative counter in millijoules.
+	defaultEnergyMetric = "DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION"
+	// DCGM_FI_DEV_POWER_USAGE is instantaneous power in watts.
+	defaultPowerMetric = "DCGM_FI_DEV_POWER_USAGE"
+
+	gpuLabel   = "gpu"
+	uuidLabel  = "UUID"
+	modelLabel = "modelName"
+)
+
+func init() {
+	provider.RegisterEnergy("dcgm", func(config map[string]string) (provider.EnergyProvider, error) {
+		return New(config), nil
+	})
+}
+
+// DCGMProvider implements provider.EnergyProvider by scraping dcgm-exporter.
+type DCGMProvider struct {
+	endpoint     string
+	energyMetric string
+	powerMetric  string
+	client       *http.Client
+
+	mu      sync.Mutex
+	windows map[string]float64 // windowID -> start energy in joules
+}
+
+// New builds a DCGMProvider from a config map. Unset keys take their defaults.
+func New(config map[string]string) *DCGMProvider {
+	endpoint := config["endpoint"]
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+	energyMetric := config["energy-metric"]
+	if energyMetric == "" {
+		energyMetric = defaultEnergyMetric
+	}
+	powerMetric := config["power-metric"]
+	if powerMetric == "" {
+		powerMetric = defaultPowerMetric
+	}
+	return &DCGMProvider{
+		endpoint:     endpoint,
+		energyMetric: energyMetric,
+		powerMetric:  powerMetric,
+		client:       &http.Client{Timeout: 10 * time.Second},
+		windows:      make(map[string]float64),
+	}
+}
+
+// Name returns the provider identifier used in metric labels and logs.
+func (d *DCGMProvider) Name() string { return "dcgm" }
+
+// BeginWindow snapshots cumulative GPU energy at the start of the window.
+func (d *DCGMProvider) BeginWindow(ctx context.Context, windowID string) error {
+	joules, err := d.totalEnergyJoules(ctx)
+	if err != nil {
+		return err
+	}
+	d.mu.Lock()
+	d.windows[windowID] = joules
+	d.mu.Unlock()
+	return nil
+}
+
+// EndWindow returns the joules consumed since BeginWindow, summed across all
+// GPUs on the node. A counter reset (e.g. driver reload) is clamped to 0 so the
+// value is never negative, per the EnergyProvider contract.
+func (d *DCGMProvider) EndWindow(ctx context.Context, windowID string) (float64, error) {
+	d.mu.Lock()
+	start, ok := d.windows[windowID]
+	delete(d.windows, windowID)
+	d.mu.Unlock()
+	if !ok {
+		return 0, fmt.Errorf("window %q not found", windowID)
+	}
+	end, err := d.totalEnergyJoules(ctx)
+	if err != nil {
+		return 0, err
+	}
+	joules := end - start
+	if joules < 0 {
+		joules = 0
+	}
+	return joules, nil
+}
+
+// IdlePower returns the current GPU power draw in watts, summed across GPUs.
+func (d *DCGMProvider) IdlePower(ctx context.Context) (float64, error) {
+	vals, err := d.sample(ctx, d.powerMetric)
+	if err != nil {
+		return 0, err
+	}
+	var watts float64
+	for _, v := range vals {
+		watts += v
+	}
+	return watts, nil
+}
+
+// Devices enumerates the GPUs reported by dcgm-exporter, one per energy series.
+func (d *DCGMProvider) Devices(ctx context.Context) ([]provider.Device, error) {
+	lines, err := d.rawLines(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var devices []provider.Device
+	for _, line := range lines {
+		if !metricLine(line, d.energyMetric) {
+			continue
+		}
+		id := extractLabel(line, uuidLabel)
+		if id == "" {
+			id = extractLabel(line, gpuLabel)
+		}
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		name := extractLabel(line, modelLabel)
+		if name == "" {
+			name = "GPU " + extractLabel(line, gpuLabel)
+		}
+		devices = append(devices, provider.Device{ID: id, Name: name, Type: "gpu"})
+	}
+	return devices, nil
+}
+
+// totalEnergyJoules sums the energy counter (millijoules) across GPUs and
+// converts to joules. It errors when the metric is absent so a failed or empty
+// scrape is not silently read as zero energy.
+func (d *DCGMProvider) totalEnergyJoules(ctx context.Context) (float64, error) {
+	vals, err := d.sample(ctx, d.energyMetric)
+	if err != nil {
+		return 0, err
+	}
+	if len(vals) == 0 {
+		return 0, fmt.Errorf("metric %q not found at %s", d.energyMetric, d.endpoint)
+	}
+	var milliJoules float64
+	for _, v := range vals {
+		milliJoules += v
+	}
+	return milliJoules / 1000.0, nil
+}
+
+// sample returns the value of every series of the named metric (one per GPU).
+func (d *DCGMProvider) sample(ctx context.Context, metric string) ([]float64, error) {
+	lines, err := d.rawLines(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var vals []float64
+	for _, line := range lines {
+		if !metricLine(line, metric) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		vals = append(vals, v)
+	}
+	return vals, nil
+}
+
+func (d *DCGMProvider) rawLines(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scraping %s: %w", d.endpoint, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(body), "\n"), nil
+}
+
+// metricLine reports whether a Prometheus text line is a sample of metric — the
+// metric name followed by '{' labels or a space before the value. It excludes
+// HELP/TYPE comments and metrics that merely share a name prefix.
+func metricLine(line, metric string) bool {
+	if !strings.HasPrefix(line, metric) {
+		return false
+	}
+	rest := line[len(metric):]
+	return strings.HasPrefix(rest, "{") || strings.HasPrefix(rest, " ")
+}
+
+// extractLabel returns the value of label in a Prometheus text line, or "".
+func extractLabel(line, label string) string {
+	key := label + `="`
+	idx := strings.Index(line, key)
+	if idx < 0 {
+		return ""
+	}
+	start := idx + len(key)
+	end := strings.Index(line[start:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return line[start : start+end]
+}

--- a/internal/provider/energy/dcgm/dcgm_test.go
+++ b/internal/provider/energy/dcgm/dcgm_test.go
@@ -1,0 +1,213 @@
+package dcgm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// Interface compliance is mandatory (docs/guides/writing-a-provider.md).
+var _ provider.EnergyProvider = (*DCGMProvider)(nil)
+
+func TestImplementsInterface(t *testing.T) {
+	var _ provider.EnergyProvider = (*DCGMProvider)(nil)
+}
+
+// TestRegisteredWithRegistry verifies init() wired the provider into the
+// registry so the agent can select it by name (-energy-provider dcgm).
+func TestRegisteredWithRegistry(t *testing.T) {
+	p, err := provider.NewEnergy("dcgm", nil)
+	if err != nil {
+		t.Fatalf("NewEnergy(dcgm): %v", err)
+	}
+	if p.Name() != "dcgm" {
+		t.Errorf("registered provider Name() = %q, want \"dcgm\"", p.Name())
+	}
+}
+
+// energyBody renders a dcgm-exporter payload for the energy counter (mJ), one
+// series per supplied per-GPU value.
+func energyBody(mJ ...float64) string {
+	s := "# HELP DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION Total energy since boot (mJ).\n" +
+		"# TYPE DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION counter\n"
+	for i, v := range mJ {
+		s += fmt.Sprintf("DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{gpu=\"%d\",UUID=\"GPU-%d\",modelName=\"NVIDIA H100\"} %g\n", i, i, v)
+	}
+	return s
+}
+
+// powerBody renders a dcgm-exporter payload for the power gauge (watts).
+func powerBody(w ...float64) string {
+	s := "# TYPE DCGM_FI_DEV_POWER_USAGE gauge\n"
+	for i, v := range w {
+		s += fmt.Sprintf("DCGM_FI_DEV_POWER_USAGE{gpu=\"%d\",UUID=\"GPU-%d\",modelName=\"NVIDIA H100\"} %g\n", i, i, v)
+	}
+	return s
+}
+
+// flipServer serves a body the test can change between scrapes, so a single
+// endpoint can simulate the energy counter advancing across a window.
+type flipServer struct {
+	mu   sync.Mutex
+	body string
+}
+
+func (f *flipServer) set(b string) {
+	f.mu.Lock()
+	f.body = b
+	f.mu.Unlock()
+}
+
+func (f *flipServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	f.mu.Lock()
+	b := f.body
+	f.mu.Unlock()
+	fmt.Fprint(w, b) //nolint:errcheck
+}
+
+func newProvider(endpoint string) *DCGMProvider {
+	return &DCGMProvider{
+		endpoint:     endpoint,
+		energyMetric: defaultEnergyMetric,
+		powerMetric:  defaultPowerMetric,
+		client:       &http.Client{},
+		windows:      map[string]float64{},
+	}
+}
+
+func TestName(t *testing.T) {
+	if got := newProvider("").Name(); got != "dcgm" {
+		t.Errorf("Name() = %q, want \"dcgm\"", got)
+	}
+}
+
+func TestBeginEndWindowReturnsJoules(t *testing.T) {
+	// Two GPUs. start = 1000+2000 mJ, end = 4000+6000 mJ.
+	// delta = (3000+4000) mJ = 7000 mJ = 7 J.
+	fs := &flipServer{body: energyBody(1000, 2000)}
+	ts := httptest.NewServer(fs)
+	defer ts.Close()
+	p := newProvider(ts.URL)
+
+	if err := p.BeginWindow(context.Background(), "w1"); err != nil {
+		t.Fatalf("BeginWindow: %v", err)
+	}
+	fs.set(energyBody(4000, 6000))
+	got, err := p.EndWindow(context.Background(), "w1")
+	if err != nil {
+		t.Fatalf("EndWindow: %v", err)
+	}
+	if want := 7.0; got != want {
+		t.Errorf("EndWindow joules = %v, want %v", got, want)
+	}
+}
+
+func TestEndWindowUnknownWindow(t *testing.T) {
+	ts := httptest.NewServer(&flipServer{body: energyBody(1000)})
+	defer ts.Close()
+	p := newProvider(ts.URL)
+	if _, err := p.EndWindow(context.Background(), "missing"); err == nil {
+		t.Fatal("expected error for unknown window, got nil")
+	}
+}
+
+func TestEndWindowNeverNegative(t *testing.T) {
+	// Counter reset (driver reload): end < start must clamp to 0, not go negative.
+	fs := &flipServer{body: energyBody(10000)}
+	ts := httptest.NewServer(fs)
+	defer ts.Close()
+	p := newProvider(ts.URL)
+	if err := p.BeginWindow(context.Background(), "w"); err != nil {
+		t.Fatalf("BeginWindow: %v", err)
+	}
+	fs.set(energyBody(500))
+	got, err := p.EndWindow(context.Background(), "w")
+	if err != nil {
+		t.Fatalf("EndWindow: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("EndWindow after counter reset = %v, want 0", got)
+	}
+}
+
+func TestIdlePowerSumsDevices(t *testing.T) {
+	ts := httptest.NewServer(&flipServer{body: powerBody(70, 80, 90)})
+	defer ts.Close()
+	p := newProvider(ts.URL)
+	got, err := p.IdlePower(context.Background())
+	if err != nil {
+		t.Fatalf("IdlePower: %v", err)
+	}
+	if want := 240.0; got != want {
+		t.Errorf("IdlePower = %v, want %v", got, want)
+	}
+}
+
+func TestDevices(t *testing.T) {
+	ts := httptest.NewServer(&flipServer{body: energyBody(1, 2)})
+	defer ts.Close()
+	p := newProvider(ts.URL)
+	devs, err := p.Devices(context.Background())
+	if err != nil {
+		t.Fatalf("Devices: %v", err)
+	}
+	if len(devs) != 2 {
+		t.Fatalf("got %d devices, want 2", len(devs))
+	}
+	if devs[0].ID != "GPU-0" || devs[0].Name != "NVIDIA H100" || devs[0].Type != "gpu" {
+		t.Errorf("devices[0] = %+v, want {GPU-0 NVIDIA H100 gpu}", devs[0])
+	}
+}
+
+func TestBeginWindowMetricAbsent(t *testing.T) {
+	ts := httptest.NewServer(&flipServer{body: "# nothing useful here\n"})
+	defer ts.Close()
+	p := newProvider(ts.URL)
+	if err := p.BeginWindow(context.Background(), "w"); err == nil {
+		t.Fatal("expected error when energy metric absent, got nil")
+	}
+}
+
+func TestScrapeUnreachable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := ts.URL
+	ts.Close() // close before any request so the scrape fails
+	p := newProvider(addr)
+	if err := p.BeginWindow(context.Background(), "w"); err == nil {
+		t.Fatal("expected connection error, got nil")
+	}
+}
+
+func TestNewDefaultsAndOverrides(t *testing.T) {
+	p := New(nil)
+	if p.endpoint != defaultEndpoint || p.energyMetric != defaultEnergyMetric || p.powerMetric != defaultPowerMetric {
+		t.Errorf("New(nil) defaults wrong: %+v", p)
+	}
+	p = New(map[string]string{"endpoint": "http://x:9400/metrics", "energy-metric": "FOO", "power-metric": "BAR"})
+	if p.endpoint != "http://x:9400/metrics" || p.energyMetric != "FOO" || p.powerMetric != "BAR" {
+		t.Errorf("New(config) overrides wrong: %+v", p)
+	}
+}
+
+func TestMetricLine(t *testing.T) {
+	cases := []struct {
+		line   string
+		metric string
+		want   bool
+	}{
+		{`DCGM_FI_DEV_POWER_USAGE{gpu="0"} 70`, "DCGM_FI_DEV_POWER_USAGE", true},
+		{`DCGM_FI_DEV_POWER_USAGE 70`, "DCGM_FI_DEV_POWER_USAGE", true},
+		{`# HELP DCGM_FI_DEV_POWER_USAGE help text`, "DCGM_FI_DEV_POWER_USAGE", false},
+		{`DCGM_FI_DEV_POWER_USAGE_LIMIT{} 1`, "DCGM_FI_DEV_POWER_USAGE", false},
+	}
+	for _, c := range cases {
+		if got := metricLine(c.line, c.metric); got != c.want {
+			t.Errorf("metricLine(%q, %q) = %v, want %v", c.line, c.metric, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
_Recreated from #53 (commit history cleaned; supersedes that PR)._

Implements #35.

A pure-Go `EnergyProvider` that scrapes a node-local **dcgm-exporter** Prometheus endpoint (default `http://localhost:9400/metrics`) — for clusters already running dcgm-exporter (e.g. via the GPU Operator) alongside, or instead of, in-process NVML.

### What it does
- **Energy** — `DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION` (mJ cumulative counter): `BeginWindow` snapshots it, `EndWindow` returns the joules consumed in between, summed across all GPUs on the node (mJ→J). A counter reset (driver reload) clamps to 0 — never negative.
- **Idle power** — sum of `DCGM_FI_DEV_POWER_USAGE` (W).
- **Devices** — enumerated from the energy-series labels.
- Registered as `dcgm`; selectable via `-energy-provider dcgm` / `energyProvider.type: dcgm`.

### Design notes
- Pure Go, no CGO or Python, cross-platform (unit-testable without GPUs).
- Resolution is bounded by the dcgm-exporter scrape interval; for the tightest window alignment prefer `nvml`. Noted in the package doc and the compatibility matrix.

### Tests
12 `httptest`-based unit tests — interface compliance, registry wiring, multi-GPU window delta, counter-reset clamp, idle-power sum, device enumeration, metric-absent &amp; unreachable errors, config defaults/overrides, metric-line matching. All pass.

### Not in this PR (needs hardware/CI)
Full `measurement-agent` build (pulls in the linux-only nvml/amd providers) and on-GPU validation — tracked under the GPU CI runner (#36).

### Files
- `internal/provider/energy/dcgm/` — provider + tests
- `cmd/measurement-agent/main.go` — register `dcgm`, extend `-energy-provider` help
- `helm/aitra-meter/values.yaml`, `docs/reference/{configuration,compatibility}.md` — docs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwEoubps4f9eAPU45sF4bP)_