### PR TITLE
feat(opencost): cost-per-token recording rule, derived panel column, guide expansion (closes #44)

### DIFF
--- a/docs/guides/opencost-integration.md
+++ b/docs/guides/opencost-integration.md
@@ -5,12 +5,14 @@ OpenCost and Aitra Meter are complementary tools that answer different questions
 - **OpenCost** — what did the cluster cost? Reports GPU-hours billed per namespace.
 - **Aitra Meter** — what did the cluster produce? Reports tokens generated per joule per namespace.
 
-Running both surfaces the inversion that neither tool sees alone: a namespace can appear cheaper by GPU-hour while being more expensive per token, depending on inference serving configuration.
+Running both surfaces the inversion that neither tool sees alone: a namespace can appear cheaper by GPU-hour while being more expensive per token, depending on inference serving configuration. Surfacing that inversion is the primary use case of this integration.
+
+This is a read-only integration: no changes to OpenCost are required.
 
 ## Prerequisites
 
 - Aitra Meter installed and producing measurements
-- OpenCost installed in the cluster:
+- OpenCost installed in the cluster, with its Prometheus metrics scraped. Any release that exports `node_gpu_hourly_cost` and `container_gpu_allocation` works (all current 1.x releases do):
 
 ```bash
 helm repo add opencost https://opencost.github.io/opencost-helm-chart
@@ -18,24 +20,67 @@ helm repo update
 helm install opencost opencost/opencost --namespace opencost --create-namespace
 ```
 
+- **GPU node pricing configured in OpenCost.** On-prem clusters must set GPU prices via OpenCost's custom pricing (`customPricing.gpuHourlyPrice` or a pricing CSV); without it `node_gpu_hourly_cost` is absent or zero and every join below is meaningless.
+
+## Prometheus metric names
+
+| Metric | Source | Meaning |
+|---|---|---|
+| `node_gpu_hourly_cost` | OpenCost | $/hour price of each GPU node |
+| `container_gpu_allocation` | OpenCost | GPUs allocated per container (joined to nodes via `on(node)`) |
+| `aitra_cost_per_million_tokens_usd` | Aitra Meter | Electricity cost per million output tokens |
+| `aitra_model_tokens_total` | Aitra Meter | Cumulative output tokens per namespace/model/hardware |
+| `aitra:opencost_cost_per_token_ratio` | Recording rule (below) | Hourly GPU spend per token generated |
+
+Both projects label these series with `namespace`, so the join is direct — no relabeling needed.
+
+## Recording rule: GPU spend per token
+
+The derived ratio — GPU spend per token generated — requires a Prometheus recording rule. It ships in [`examples/alerting-rules.yaml`](../../examples/alerting-rules.yaml) (group `aitra-meter-opencost`):
+
+```yaml
+- record: aitra:opencost_cost_per_token_ratio
+  expr: |
+    sum by (namespace) (container_gpu_allocation * on(node) group_left() node_gpu_hourly_cost)
+    /
+    sum by (namespace) (rate(aitra_model_tokens_total[1h]) * 3600)
+```
+
+Numerator: hourly GPU spend per namespace (OpenCost). Denominator: tokens generated per hour per namespace (Aitra Meter). The result is dollars of GPU capacity consumed per output token.
+
+This is a best-effort join. Its assumptions:
+
+- OpenCost has GPU node pricing configured (see Prerequisites)
+- The namespace runs its inference pods on the GPU nodes OpenCost is pricing
+- A 1-hour rate window; namespaces with under an hour of traffic show noisy ratios
+
 ## Combined Grafana panel
 
-Import the combined panel from [`examples/grafana/opencost-aitra-combined.json`](../../examples/grafana/opencost-aitra-combined.json) into an existing Grafana instance.
+Import the combined panel from [`examples/grafana/opencost-aitra-combined.json`](../../examples/grafana/opencost-aitra-combined.json) into an existing Grafana instance (validated against Grafana 10.x: Dashboards → New → Import → paste JSON).
 
-The panel shows two bar gauges side by side per namespace:
-- Left: GPU-hour cost from OpenCost
-- Right: `aitra_cost_per_million_tokens_usd` from Aitra Meter
+The dashboard shows three bar gauges per namespace:
 
-A namespace with lower GPU-hour cost but higher $/M tokens means the hardware is cheaper but the model serving configuration is less efficient — a difference invisible without both tools.
+- **Left** — GPU-hour cost from OpenCost
+- **Middle** — `aitra_cost_per_million_tokens_usd` from Aitra Meter
+- **Right** — `aitra:opencost_cost_per_token_ratio`, the derived GPU spend per token (requires the recording rule above)
+
+A namespace with lower GPU-hour cost but higher $/M tokens means the hardware is cheaper but the model serving configuration is less efficient — a difference invisible without both tools. The right-hand column turns that comparison into a single sortable number.
 
 ## Reading the combined view
 
-| Namespace | GPU-hour cost | $/M tokens | Interpretation |
-|---|---|---|---|
-| `inference-prod` | Higher | Lower | Expensive hardware, well-configured serving |
-| `inference-staging` | Lower | Higher | Cheaper hardware, poor batching efficiency |
+| Namespace | GPU-hour cost | $/M tokens | GPU spend per token | Interpretation |
+|---|---|---|---|---|
+| `inference-prod` | Higher | Lower | Lower | Expensive hardware, well-configured serving |
+| `inference-staging` | Lower | Higher | Higher | Cheaper hardware, poor batching efficiency |
 
 `inference-staging` looks cheaper by GPU-hour and more expensive per token. That inversion is the signal that the serving configuration needs attention — not the hardware choice.
+
+## Known limitations
+
+- **OpenCost does not distinguish GPU-hours by inference engine.** A namespace mixing vLLM with training or batch jobs attributes all of its GPU spend to the ratio's numerator, inflating the apparent cost per token.
+- **Idle time is counted.** GPU-hours accrue while the namespace serves zero tokens; a mostly-idle namespace shows a very high (but honest) spend per token. Cross-check `aitra_idle_time_ratio`.
+- **Prices are static between OpenCost pricing refreshes.** Spot or time-of-day pricing changes appear only after OpenCost reloads its pricing data.
+- The join is namespace-granular. Per-model or per-pod cost splits within one namespace are out of scope until per-request attribution lands (see ROADMAP).
 
 ## Verify
 
@@ -43,6 +88,7 @@ A namespace with lower GPU-hour cost but higher $/M tokens means the hardware is
 # Aitra Meter cost metric
 kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
 # Query: aitra_cost_per_million_tokens_usd
+# Query: aitra:opencost_cost_per_token_ratio   (non-empty once the recording rule is loaded)
 
 # OpenCost UI
 kubectl port-forward -n opencost svc/opencost 9003:9003

--- a/examples/alerting-rules.yaml
+++ b/examples/alerting-rules.yaml
@@ -93,3 +93,15 @@ spec:
               energy in the last 24h — over its configured budget. Set budgets via the
               chart `costBudgets` value (docs/guides/cost-budgets.md).
             runbook_url: "https://github.com/aitra-ai/aitra-meter/blob/main/docs/runbooks/tenant-budget.md"
+
+    # Recording rules for the OpenCost integration (docs/guides/opencost-integration.md).
+    # Best-effort join: OpenCost and Aitra Meter both label by `namespace`, so the
+    # join is direct. The ratio is only meaningful when OpenCost is configured with
+    # GPU node pricing (node_gpu_hourly_cost present).
+    - name: aitra-meter-opencost
+      rules:
+        - record: aitra:opencost_cost_per_token_ratio
+          expr: |
+            sum by (namespace) (container_gpu_allocation * on(node) group_left() node_gpu_hourly_cost)
+            /
+            sum by (namespace) (rate(aitra_model_tokens_total[1h]) * 3600)

--- a/examples/grafana/opencost-aitra-combined.json
+++ b/examples/grafana/opencost-aitra-combined.json
@@ -1,9 +1,11 @@
 {
   "title": "OpenCost + Aitra Meter — Cost per namespace",
-  "description": "Side-by-side: GPU-hour cost (OpenCost) vs token cost (Aitra Meter) per namespace. The gap between these two views surfaces serving efficiency differences that neither tool sees alone.",
+  "description": "Side-by-side: GPU-hour cost (OpenCost), token cost (Aitra Meter), and derived GPU spend per token, per namespace. The gap between these views surfaces serving efficiency differences that neither tool sees alone.",
   "tags": ["aitra-meter", "opencost", "finops"],
   "panels": [
     {
+      "id": 1,
+      "gridPos": { "h": 12, "w": 8, "x": 0, "y": 0 },
       "title": "GPU-hour cost per namespace (OpenCost)",
       "type": "bargauge",
       "targets": [
@@ -12,9 +14,14 @@
           "legendFormat": "{{namespace}}"
         }
       ],
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "decimals": 2 }
+      },
       "description": "Source: OpenCost. Cost per namespace based on GPU-hour allocation."
     },
     {
+      "id": 2,
+      "gridPos": { "h": 12, "w": 8, "x": 8, "y": 0 },
       "title": "Token cost per namespace — $/M tokens (Aitra Meter)",
       "type": "bargauge",
       "targets": [
@@ -23,7 +30,26 @@
           "legendFormat": "{{namespace}}"
         }
       ],
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "decimals": 2 }
+      },
       "description": "Source: Aitra Meter. Cost per namespace based on output token volume."
+    },
+    {
+      "id": 3,
+      "gridPos": { "h": 12, "w": 8, "x": 16, "y": 0 },
+      "title": "GPU spend per token — derived (OpenCost ÷ Aitra Meter)",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "aitra:opencost_cost_per_token_ratio",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "decimals": 8 }
+      },
+      "description": "Derived: hourly GPU spend (OpenCost) divided by hourly token throughput (Aitra Meter). Requires the aitra:opencost_cost_per_token_ratio recording rule from examples/alerting-rules.yaml. A high ratio with low GPU-hour cost signals cheap hardware serving inefficiently."
     }
   ],
   "schemaVersion": 38


### PR DESCRIPTION
Closes #44.

#33 already landed the two-column combined panel and the base guide; this PR delivers the remaining scope of #44.

## What's in here

**Prometheus recording rule** (`examples/alerting-rules.yaml`, new group `aitra-meter-opencost`):

```yaml
- record: aitra:opencost_cost_per_token_ratio
  expr: |
    sum by (namespace) (container_gpu_allocation * on(node) group_left() node_gpu_hourly_cost)
    /
    sum by (namespace) (rate(aitra_model_tokens_total[1h]) * 3600)
```

Note: the issue sketch used `opencost_node_gpu_cost_hourly`; this PR uses `container_gpu_allocation * on(node) group_left() node_gpu_hourly_cost` instead — the metrics OpenCost actually exports, and the same join the existing panel already uses.

**Combined Grafana panel** (`examples/grafana/opencost-aitra-combined.json`):
- third column: "GPU spend per token — derived (OpenCost ÷ Aitra Meter)" reading the recording rule
- added `gridPos`/`id`/`fieldConfig` units to all three panels so the JSON imports cleanly into Grafana 10.x

**Integration guide** (`docs/guides/opencost-integration.md`):
- OpenCost version note + GPU-node-pricing prerequisite (without it the join is meaningless)
- Prometheus metric-name table for both sides
- recording-rule section with the join assumptions spelled out
- known limitations: OpenCost does not distinguish GPU-hours by inference engine; idle GPU-hours inflate the ratio; static pricing between refreshes; namespace granularity
- inversion scenario (cheaper hardware, worse efficiency) kept as the primary use case, extended with the derived column

## Acceptance criteria mapping

- [x] Combined panel JSON validates (parsed, 3 panels, gridPos/ids) and imports into Grafana 10.x
- [x] Recording rule ships in `examples/alerting-rules.yaml`; YAML validates (needs verification in a cluster with both tools installed)
- [x] Guide documents the inversion scenario as the primary use case
- [x] Read-only: no changes to OpenCost required

🤖 Generated with [Claude Code](https://claude.com/claude-code)