### PR TITLE
docs(proposals): draft OTel GenAI semconv energy proposal (part of #38)

### DIFF
--- a/docs/proposals/otel-semconv-energy-metrics.yaml
+++ b/docs/proposals/otel-semconv-energy-metrics.yaml
@@ -1,0 +1,75 @@
+# Draft registry addition for open-telemetry/semantic-conventions-genai,
+# model/gen-ai/metrics.yaml (file_format: definition/2).
+# Part of https://github.com/aitra-ai/aitra-meter/issues/38 — see
+# otel-semconv-energy.md in this directory for motivation and semantics.
+#
+# k8s.namespace.name and k8s.cluster.name are defined in the main
+# semantic-conventions registry; whether they can be ref'd across registries
+# is an open question for upstream reviewers (fallback: drop to emitter docs).
+file_format: definition/2
+attribute_groups:
+  - id: metric_attributes.gen_ai.infrastructure
+    visibility: internal
+    attributes:
+      - ref: gen_ai.request.model
+        requirement_level: recommended
+      - ref: gen_ai.provider.name
+        requirement_level: recommended
+      - ref: server.address
+        brief: The node the accelerator is attached to.
+        requirement_level: recommended
+      - ref: k8s.namespace.name
+        requirement_level: opt_in
+      - ref: k8s.cluster.name
+        requirement_level: opt_in
+metrics:
+  - name: gen_ai.infrastructure.energy
+    instrument: counter
+    unit: "J"
+    brief: 'Cumulative accelerator energy consumed serving GenAI workloads.'
+    stability: development
+    annotations:
+      code_generation:
+        metric_value_type: double
+    attributes:
+      - ref_group: metric_attributes.gen_ai.infrastructure
+  - name: gen_ai.infrastructure.energy.per_token
+    instrument: gauge
+    unit: "J"
+    brief: 'Accelerator energy per generated output token over the most recent measurement window.'
+    note: >
+      Computed as the accelerator energy delta divided by the output-token delta
+      over a fixed measurement window (window length is an implementation choice).
+      MUST NOT be emitted for windows with zero output tokens; report
+      `gen_ai.infrastructure.idle_ratio` instead so that idle consumption
+      remains visible.
+    stability: development
+    annotations:
+      code_generation:
+        metric_value_type: double
+    attributes:
+      - ref_group: metric_attributes.gen_ai.infrastructure
+  - name: gen_ai.infrastructure.power
+    instrument: gauge
+    unit: "W"
+    brief: 'Instantaneous accelerator power draw.'
+    stability: development
+    annotations:
+      code_generation:
+        metric_value_type: double
+    attributes:
+      - ref_group: metric_attributes.gen_ai.infrastructure
+  - name: gen_ai.infrastructure.idle_ratio
+    instrument: gauge
+    unit: "1"
+    brief: 'Fraction of the measurement window during which the accelerator served no GenAI requests.'
+    note: >
+      1.0 means the accelerator drew power for the whole window without serving
+      any GenAI request. Emitters SHOULD keep reporting energy and power during
+      idle windows — idle consumption is signal, not noise.
+    stability: development
+    annotations:
+      code_generation:
+        metric_value_type: double
+    attributes:
+      - ref_group: metric_attributes.gen_ai.infrastructure

--- a/docs/proposals/otel-semconv-energy.md
+++ b/docs/proposals/otel-semconv-energy.md
@@ -1,0 +1,99 @@
+# Proposal: `gen_ai.infrastructure.energy.*` — energy semantic conventions for GenAI serving
+
+Status: **draft for internal review** — once approved, this becomes a draft PR against
+[open-telemetry/semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai).
+Tracked by [#38](https://github.com/aitra-ai/aitra-meter/issues/38).
+
+> **Note on target repository.** Issue #38 says `open-telemetry/semantic-conventions`,
+> but the GenAI conventions have since moved to the dedicated
+> `open-telemetry/semantic-conventions-genai` repository (the main repo's
+> `docs/gen-ai/` pages now redirect there). The draft PR should target the new repo;
+> the registry snippet below follows its `file_format: definition/2` schema.
+
+## Motivation
+
+The `gen_ai.*` semantic conventions describe what GenAI systems *do* — tokens used,
+operation duration, time to first chunk — but say nothing about what they *consume*.
+Energy is the missing dimension:
+
+- GenAI inference runs on accelerators drawing hundreds of watts each; clusters draw
+  megawatts. Operators are increasingly asked to report energy and carbon per
+  workload, and no OTel convention exists to express it.
+- Without a convention, every tool invents its own names, and energy data cannot be
+  joined with the `gen_ai.*` signals that already carry model and provider attributes.
+- Normalizing by output tokens (J/token) is what makes energy *actionable*: it turns
+  a hardware counter into an efficiency signal comparable across models, engines,
+  and hardware generations.
+
+## Proposed metrics
+
+Four metrics under a new `gen_ai.infrastructure.*` sub-namespace:
+
+| Name | Instrument | Unit | Description |
+|---|---|---|---|
+| `gen_ai.infrastructure.energy` | Counter | `J` | Cumulative accelerator energy consumed serving GenAI workloads |
+| `gen_ai.infrastructure.energy.per_token` | Gauge | `J` | Energy per generated output token over the most recent measurement window |
+| `gen_ai.infrastructure.power` | Gauge | `W` | Instantaneous accelerator power draw |
+| `gen_ai.infrastructure.idle_ratio` | Gauge | `1` | Fraction of the measurement window during which the accelerator served no GenAI requests |
+
+Registry snippet: [`otel-semconv-energy-metrics.yaml`](otel-semconv-energy-metrics.yaml).
+
+### Attributes
+
+Reuses existing registry attributes — no new attributes are proposed:
+
+| Attribute | Level | Why |
+|---|---|---|
+| `gen_ai.request.model` | recommended | Joins energy to the model being served |
+| `gen_ai.provider.name` | recommended | Inference engine (`vllm`, `generic-prometheus`, …) |
+| `server.address` | recommended | The node the accelerator is attached to |
+| `k8s.namespace.name` | opt-in | Chargeback boundary on Kubernetes |
+| `k8s.cluster.name` | opt-in | Multi-cluster roll-ups |
+
+### Semantics
+
+- **Measurement window.** `energy.per_token` and `idle_ratio` are window-scoped:
+  the emitter samples an interval (Aitra Meter uses 30 s), computes
+  ΔJoules ÷ Δoutput_tokens, and reports one value per window. Window length is an
+  implementation choice and deliberately not part of the convention.
+- **Attribution.** When one accelerator serves several workloads, emitters SHOULD
+  document their attribution method. Values are best-effort; the convention does
+  not mandate an attribution algorithm.
+- **Honesty.** Windows with zero output tokens MUST NOT emit `energy.per_token`
+  (division by zero) but SHOULD still emit `energy`, `power`, and `idle_ratio` —
+  idle consumption is signal, not noise.
+
+## Naming note (open question for reviewers)
+
+OTel naming guidance discourages embedding units in metric names, so this proposal
+uses `…energy` (unit `J`) and `…power` (unit `W`). Aitra Meter's shipped exporter
+currently emits `…energy.joules_total`, `…energy.joules_per_token`, and
+`…power.watts`; if the unit-free spelling is accepted upstream, the exporter will
+be renamed to match before the convention stabilizes.
+
+## Prior art
+
+- **Kepler** (CNCF) — eBPF-based pod energy attribution. Reports joules per pod but
+  is not GenAI-aware: no token normalization, no `gen_ai.*` attributes.
+- **DCGM / NVML** — hardware counters (mJ, mW) with no workload semantics.
+- **ML.ENERGY** — offline benchmark measurements of J/token; a calibration
+  reference, not a telemetry convention.
+
+None of these define how energy telemetry should be *named and attributed* in the
+GenAI context — that is the gap this proposal fills.
+
+## Working implementation
+
+[Aitra Meter](https://github.com/aitra-ai/aitra-meter) (Apache 2.0, SODA Foundation)
+ships an opt-in OTLP exporter emitting exactly these four metrics with the attribute
+set above (`internal/export/otlp/`). The pipeline is validated on production
+hardware (8×A100 cluster; H100 validation in progress) with NVML, DCGM, AMD, and
+Zeus energy providers behind a common interface.
+
+## Submission checklist (when opening the upstream draft PR)
+
+- [ ] Registry entry in `model/gen-ai/metrics.yaml` (adapt the snippet in this directory)
+- [ ] Docs table in `docs/gen-ai/gen-ai-metrics.md` (generated via the repo's `make generate`)
+- [ ] `changelog.d/` entry per upstream `CONTRIBUTING.md`
+- [ ] PR marked **draft**; body links Aitra Meter as the working implementation
+- [ ] Link the PR from Aitra Meter's README (required for Demo 2, KubeCon Japan 2026)


### PR DESCRIPTION
Part of #38 — this is the **internal review draft** of the proposal text; the actual draft PR against OpenTelemetry is a follow-up once this lands.

## What's in here

- `docs/proposals/otel-semconv-energy.md` — the proposal: motivation, the four `gen_ai.infrastructure.*` metrics (energy counter, energy-per-token, power, idle ratio), attribute reuse from the existing registry, measurement-window / attribution / honesty semantics, prior art (Kepler, DCGM, ML.ENERGY), Aitra Meter as the working implementation, and a submission checklist.
- `docs/proposals/otel-semconv-energy-metrics.yaml` — registry snippet in the upstream `file_format: definition/2` schema, matching the current `model/gen-ai/metrics.yaml` layout.

## Two findings reviewers should weigh in on

1. **The target repo moved.** GenAI semantic conventions were extracted from `open-telemetry/semantic-conventions` into `open-telemetry/semantic-conventions-genai` (the main repo's gen-ai pages now redirect). Issue #38 predates the move; the draft PR should target the new repo.
2. **Naming.** OTel guidance discourages units in metric names, so the proposal spells them `…energy` (unit `J`) / `…power` (unit `W`). Our shipped exporter emits `…energy.joules_total` / `…power.watts` etc. If we adopt the unit-free spelling upstream, the exporter should be renamed before the convention stabilizes — flagged as an open question in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)