### PR TITLE
feat(grafana): audience-specific dashboards with Helm auto-provisioning (closes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ Full metrics reference: [docs/reference/metrics.md](docs/reference/metrics.md)
 | 4. Idle consumption | How much energy is consumed while producing no tokens? |
 | 5. Carbon and cost | What is the carbon and energy cost per token? |
 
+## Grafana dashboards
+
+Four dashboard JSON files ship in `helm/aitra-meter/files/`. Set `grafana.enabled=true` to auto-provision them via the Grafana sidecar (no manual import); they also import manually.
+
+| Dashboard | uid | Audience |
+|---|---|---|
+| Aitra Meter (overview) | `aitra-meter-v1` | Everyone — J/token, tokens/J, idle ratio, measurement CV, $/M tokens |
+| Cost Attribution | `aitra-cost-attribution` | FinOps — cost by model, namespace/tenant, cluster; chargeback table |
+| AI Efficiency | `aitra-efficiency` | Infrastructure — tokens/s per watt, serving utilisation, J/token, TTFT/TPOT P95 (vLLM passthrough) |
+| Hardware Efficiency Comparison | `aitra-hardware-efficiency` | Capacity planning — J/token and $/M tokens across GPU types; needs ≥2 `hardware` label values |
+
 ## CNCF integrations
 
 | Project | Integration |

--- a/helm/aitra-meter/files/grafana-dashboard-cost-attribution.json
+++ b/helm/aitra-meter/files/grafana-dashboard-cost-attribution.json
@@ -1,0 +1,138 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "title": "Aitra Meter — Cost Attribution",
+  "uid": "aitra-cost-attribution",
+  "description": "Energy cost attribution for FinOps: cost by model, namespace/tenant, and cluster, plus a chargeback table. All costs are energy costs derived from measured J/token and the configured electricity price — not hardware amortisation.",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["aitra", "ai", "inference", "cost", "finops"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0
+      },
+      {
+        "name": "cost_per_kwh",
+        "label": "Electricity cost (USD/kWh)",
+        "description": "Set to match siteConfig.electricityCostPerKwh (Helm default: 0.12).",
+        "type": "textbox",
+        "query": "0.12",
+        "current": { "text": "0.12", "value": "0.12" },
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Cost by model",
+      "description": "USD per million output tokens (energy cost only), per model x hardware.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_cost_per_million_tokens_usd",
+          "legendFormat": "{{model}} ({{hardware}}) — {{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    },
+    {
+      "id": 2,
+      "title": "Cost by namespace / tenant",
+      "description": "Energy cost (USD) accrued per namespace over the selected dashboard time range.",
+      "type": "barchart",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (namespace) (increase(aitra_tenant_cost_usd_total[$__range]))",
+          "legendFormat": "{{namespace}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    },
+    {
+      "id": 3,
+      "title": "Cluster energy cost per 1M tokens",
+      "description": "aitra_cluster_j_per_token converted to USD per million tokens: J/token / 3.6e6 J/kWh x $cost_per_kwh x 1e6. Adjust the cost_per_kwh dashboard variable to match your site.",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 4 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_cluster_j_per_token * $cost_per_kwh / 3.6",
+          "legendFormat": "{{cluster}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 2 } }
+    },
+    {
+      "id": 4,
+      "title": "Cost per 1M tokens (current)",
+      "description": "Latest aitra_cost_per_million_tokens_usd per model x hardware, priced by the aggregation service from SiteConfig.",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 4 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_cost_per_million_tokens_usd",
+          "legendFormat": "{{model}} ({{hardware}})",
+          "refId": "A"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 2 } }
+    },
+    {
+      "id": 5,
+      "title": "Chargeback table",
+      "description": "Cumulative energy cost (USD) attributed per tenant, broken down by namespace, team, and cost_center labels.",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (namespace, team, cost_center) (aitra_tenant_cost_usd_total)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": { "Value": "Cost (USD, cumulative)" }
+          }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    }
+  ]
+}

--- a/helm/aitra-meter/files/grafana-dashboard-efficiency.json
+++ b/helm/aitra-meter/files/grafana-dashboard-efficiency.json
@@ -1,0 +1,145 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "title": "Aitra Meter — AI Efficiency",
+  "uid": "aitra-efficiency",
+  "description": "AI inference efficiency for infrastructure engineers: token throughput per watt, GPU serving utilisation, J/token, energy per 1M tokens, and vLLM latency percentiles. The TTFT/TPOT panels read vLLM metrics directly (passthrough) — Aitra Meter does not re-expose them.",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["aitra", "ai", "inference", "energy", "efficiency"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Tokens/sec per GPU watt",
+      "description": "aitra_gpu_utilization_efficiency: output tokens per second per GPU watt. Bridges GPU utilisation and token throughput — higher is better.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_gpu_utilization_efficiency",
+          "legendFormat": "{{model}} ({{hardware}}) — {{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "id": 2,
+      "title": "GPU serving utilization",
+      "description": "Fraction of elapsed time each node was serving inference requests. Distinct from DCGM SM utilisation.",
+      "type": "gauge",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_gpu_serving_utilization_ratio",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0, "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "J/token by model",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "aitra_j_per_token",
+          "legendFormat": "{{model}} ({{hardware}}) — {{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "joule" } }
+    },
+    {
+      "id": 4,
+      "title": "Energy per 1M tokens",
+      "description": "Joules per one million output tokens for the current measurement window, averaged per model x hardware.",
+      "type": "barchart",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "avg by (model, hardware) (aitra_model_energy_per_1m_tokens)",
+          "legendFormat": "{{model}} ({{hardware}})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "joule" } }
+    },
+    {
+      "id": 5,
+      "title": "TTFT P95 (vLLM passthrough)",
+      "description": "Time to first token, P95, read directly from vLLM's vllm:time_to_first_token_seconds histogram. Not an aitra_ metric — Aitra Meter does not duplicate it. Empty if the inference server is not vLLM or its metrics are not scraped.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, model_name) (rate(vllm:time_to_first_token_seconds_bucket[5m])))",
+          "legendFormat": "TTFT P95 — {{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 6,
+      "title": "TPOT P95 (vLLM passthrough)",
+      "description": "Time per output token, P95, read directly from vLLM's vllm:time_per_output_token_seconds histogram. Not an aitra_ metric — Aitra Meter does not duplicate it. Empty if the inference server is not vLLM or its metrics are not scraped.",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, model_name) (rate(vllm:time_per_output_token_seconds_bucket[5m])))",
+          "legendFormat": "TPOT P95 — {{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    }
+  ]
+}

--- a/helm/aitra-meter/files/grafana-dashboard-hardware-efficiency.json
+++ b/helm/aitra-meter/files/grafana-dashboard-hardware-efficiency.json
@@ -1,0 +1,138 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "title": "Aitra Meter — Hardware Efficiency Comparison",
+  "uid": "aitra-hardware-efficiency",
+  "description": "Cross-hardware J/token comparison for capacity planning: relative J/token and cost/1M tokens across GPU types for the same model under comparable load. Only meaningful when more than one hardware label value is reporting.",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["aitra", "ai", "inference", "energy", "hardware"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "How to read this dashboard",
+      "type": "text",
+      "gridPos": { "x": 0, "y": 0, "w": 16, "h": 5 },
+      "options": {
+        "mode": "markdown",
+        "content": "This dashboard compares **J/token across GPU hardware types** for the same model. It requires more than one distinct `hardware` label value to be meaningful.\n\n- If **Hardware types reporting** (right) shows **1**, your cluster runs a single GPU type — the panels below will show only that type and no comparison is possible. Deploy the same model on a second GPU type to populate the comparison.\n- The efficiency-ratio panel uses `hardware=\"h100\"` as the baseline. If no H100 is present it stays empty; edit the panel query to pick a baseline that exists in your cluster.\n- Comparisons are only fair under comparable load: same model, similar batch sizes and request mix. Check `aitra_measurement_cv` before trusting a number."
+      }
+    },
+    {
+      "id": 2,
+      "title": "Hardware types reporting",
+      "description": "Count of distinct hardware label values currently reporting aitra_j_per_token. Below 2 (red), the comparison panels are not meaningful.",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 5 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "count(count by (hardware) (aitra_j_per_token))",
+          "legendFormat": "hardware types",
+          "refId": "A"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 2 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "J/token by hardware × model",
+      "description": "Average J/token grouped by hardware and model. Lower is better.",
+      "type": "barchart",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 9 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "avg by (hardware, model) (aitra_j_per_token)",
+          "legendFormat": "{{model}} on {{hardware}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "joule" } }
+    },
+    {
+      "id": 4,
+      "title": "Cost per 1M tokens by hardware × model",
+      "description": "Average energy cost (USD) per million output tokens grouped by hardware and model. Lower is better.",
+      "type": "barchart",
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 9 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "avg by (hardware, model) (aitra_cost_per_million_tokens_usd)",
+          "legendFormat": "{{model}} on {{hardware}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    },
+    {
+      "id": 5,
+      "title": "Efficiency ratio vs H100 baseline",
+      "description": "Per-model ratio: H100 J/token divided by J/token on other hardware (h200, b200, l40s). A value above 1 means the other hardware produces the same tokens for less energy than H100. Empty when no H100 series or no second hardware type is present — see the instructions panel.",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 6 },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "avg by (model) (aitra_j_per_token{hardware=\"h100\"}) / on (model) group_right () avg by (model, hardware) (aitra_j_per_token{hardware=~\"h200|b200|l40s\"})",
+          "legendFormat": "h100 vs {{hardware}} — {{model}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/helm/aitra-meter/files/grafana-dashboard.json
+++ b/helm/aitra-meter/files/grafana-dashboard.json
@@ -19,6 +19,17 @@
   "version": 1,
   "refresh": "30s",
   "tags": ["aitra", "ai", "inference", "energy"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0
+      }
+    ]
+  },
   "panels": [
     {
       "id": 1,

--- a/helm/aitra-meter/templates/grafana-dashboards.yaml
+++ b/helm/aitra-meter/templates/grafana-dashboards.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aitra-meter.fullname" . }}-grafana-dashboards
+  namespace: {{ include "aitra-meter.namespace" . }}
+  labels:
+    {{- include "aitra-meter.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana-dashboards
+    {{ .Values.grafana.sidecarLabel }}: {{ .Values.grafana.sidecarLabelValue | quote }}
+  {{- with .Values.grafana.folder }}
+  annotations:
+    grafana_folder: {{ . | quote }}
+  {{- end }}
+data:
+  {{- (.Files.Glob "files/grafana-dashboard*.json").AsConfig | nindent 2 }}
+{{- end }}

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -95,6 +95,21 @@ prometheus:
     interval: 15s
     scrapeTimeout: 10s
 
+# Grafana dashboard provisioning.
+# When enabled, all dashboard JSON files in files/ (overview, cost attribution,
+# AI efficiency, hardware efficiency) are rendered into a ConfigMap labelled for
+# the Grafana dashboard sidecar (kube-prometheus-stack ships it by default), so
+# the dashboards appear in Grafana without a manual import step.
+grafana:
+  enabled: false
+  # Label key/value the Grafana sidecar watches for on dashboard ConfigMaps.
+  # kube-prometheus-stack default: grafana_dashboard=1.
+  sidecarLabel: grafana_dashboard
+  sidecarLabelValue: "1"
+  # Optional Grafana folder for the provisioned dashboards (grafana_folder
+  # annotation, honoured by the sidecar). Empty = Grafana default folder.
+  folder: ""
+
 # Storage backend — SQLite by default (embedded, no infrastructure required).
 storage:
   backend: sqlite


### PR DESCRIPTION
Closes #42.

- Three new dashboards under helm/aitra-meter/files/: Cost Attribution, AI Efficiency, Hardware Efficiency — only aitra_* metrics that exist on main
- Helm auto-provisioning wired under grafana.enabled (same sidecar/ConfigMap path as the existing overview dashboard)
- Review fix included: the pre-existing overview dashboard now defines the DS_PROMETHEUS templating variable like the new ones, so it resolves its datasource under file provisioning
- Verified with helm v3.16.4: all four dashboards render as valid JSON with grafana.enabled=true, template absent when disabled, helm lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)