### PR TITLE
feat(attribution): per-phase prefill/decode J/token via llm-d pod labels (closes #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Pre-release tags: `-alpha` tags are internal milestones. `-beta` tags are public
 - **DCGM energy provider** — pure-Go `EnergyProvider` that scrapes a node-local dcgm-exporter Prometheus endpoint; selectable via `-energy-provider dcgm` / `energyProvider.type: dcgm`. (#59)
 - **Model-level AI efficiency metric family** — `aitra_model_tokens_total` and `aitra_model_energy_per_1m_tokens`, plus SiteConfig-driven cost/carbon derivation (`aitra_cost_per_million_tokens_usd`, `aitra_co2_per_token_grams`, `aitra_tenant_cost_usd_total`) and per-node serving/idle ratios (`aitra_gpu_serving_utilization_ratio`, `aitra_idle_time_ratio`). (#60)
 - **Cost-budget and TTFT alerts** — `TenantCostBudgetExceeded` and `TTFTRegression` reference alerts, a runbook per alert, and a Helm-driven per-namespace budget mechanism (`costBudgets`). (#61)
+- **llm-d per-phase attribution** — new `role` label on `aitra_j_per_token` (empty when unset), populated from the `llm-d.ai/role` pod label to split prefill/decode J/token; `llm-d.ai/model` is now honoured as a model match hint; llm-d integration guide and Grafana prefill-vs-decode example dashboard. (#49)
 
 ### Fixed
 - Repository builds again under `-mod=readonly` (CI default): completed `go.sum` and pruned an unused `testcontainers-go`/Docker dependency tree via `go mod tidy`.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidance.
 - [Operations](docs/guides/operations.md) — upgrading, scaling, air-gapped install
 - [KEDA integration](docs/guides/keda-integration.md)
 - [OpenCost integration](docs/guides/opencost-integration.md)
+- [llm-d integration](docs/guides/llm-d-integration.md) — per-phase prefill/decode J/token for disaggregated serving
 - [Troubleshooting](docs/guides/troubleshooting.md)
 
 ### Reference

--- a/docs/guides/llm-d-integration.md
+++ b/docs/guides/llm-d-integration.md
@@ -1,0 +1,145 @@
+# llm-d integration
+
+[llm-d](https://llm-d.ai) serves large models with disaggregated prefill and
+decode: prefill pods and decode pods run on separate GPU pools, labelled with
+`llm-d.ai/role=prefill` or `llm-d.ai/role=decode`. Prefill is compute-bound,
+decode is memory-bandwidth-bound — they have different energy signatures.
+
+Aitra Meter reads the `llm-d.ai/role` label during attribution and propagates
+it into the `role` label on `aitra_j_per_token`, so each phase gets its own
+J/token series. No changes to llm-d are required — no sidecars, no CRD changes.
+
+An example dashboard is in
+[`examples/grafana/llmd-prefill-decode.json`](../../examples/grafana/llmd-prefill-decode.json).
+
+## Prerequisites
+
+- llm-d deployed with disaggregated serving (pods carry the `llm-d.ai/role` label)
+- Aitra Meter installed on the GPU nodes:
+
+```bash
+helm repo add aitra https://aitra-ai.github.io/helm-charts
+helm repo update
+helm install aitra-meter aitra/aitra-meter \
+  --namespace aitra-system \
+  --create-namespace \
+  --set cluster.name=my-cluster
+```
+
+The measurement agent scrapes the same vLLM `/metrics` endpoint
+(`vllm:generation_tokens_total`) that llm-d's own monitoring uses, and reads
+GPU energy from NVML (or DCGM/AMD SMI — see
+[energy providers](energy-providers.md)).
+
+## How attribution works
+
+For each measurement window the aggregation service looks up the Running pod
+on the reporting node and reads its labels:
+
+| Label | Used for |
+|---|---|
+| `llm-d.ai/role` | `role` metric label: `prefill` or `decode` |
+| `llm-d.ai/model` | Matching the pod to the model name reported by the inference server (multi-model nodes) |
+
+The Aitra annotations (`aitra-ai.github.io/workload`, `precision`, `team`,
+`cost-centre`) work on llm-d pods exactly as on any other pod — add them to the
+pod template if you want those dimensions too.
+
+### What appears in Prometheus
+
+```
+aitra_j_per_token{namespace="inference-prod", model="Qwen/Qwen3-32B",
+                  role="prefill", hardware="h100", ...}
+aitra_j_per_token{namespace="inference-prod", model="Qwen/Qwen3-32B",
+                  role="decode",  hardware="h100", ...}
+```
+
+Pods without the `llm-d.ai/role` label produce an empty `role` value, which
+Prometheus treats as an absent label — existing series and queries are
+unaffected, and the dimension adds no cardinality outside llm-d deployments.
+The label value is passed through verbatim; Aitra Meter does not restrict it
+to `prefill`/`decode`, so if llm-d adds new roles they appear as new series
+without a code change.
+
+### Model matching on multi-model nodes
+
+Kubernetes label values cannot contain `/`, so the `llm-d.ai/model` label
+usually holds a DNS-form name (`qwen3-32b`) while the inference server reports
+the full model ID (`Qwen/Qwen3-32B`). Aitra Meter matches the label against
+the reported name, its sanitized form, and the sanitized basename after the
+last `/` — `qwen3-32b` matches `Qwen/Qwen3-32B`.
+
+The label is only ever a positive hint: when several inference pods share a
+node, a pod whose `llm-d.ai/model` matches wins, but a pod is never excluded
+because its label does not match. If your ModelService names do not resemble
+the served model names, add the explicit
+`aitra-ai.github.io/model-name: <name>` label to the pod template — it takes
+precedence and matches exactly.
+
+## Interpreting prefill vs decode J/token
+
+Be careful with direct magnitude comparisons. J/token divides a node's GPU
+energy by the output tokens reported by the vLLM instances on that node. In
+disaggregated serving the decode pods report almost all generation tokens;
+prefill pods report few (roughly the first token per request, depending on
+llm-d version). So:
+
+- `aitra_j_per_token{role="decode"}` — joules per generated token on the
+  decode pool. This is the number comparable to conventional serving.
+- `aitra_j_per_token{role="prefill"}` — joules per token *reported by the
+  prefill instances*, which is closer to "joules of prefill per request" than
+  to a per-generated-token cost. Expect it to be much larger than the decode
+  value; that is an artifact of where tokens are counted, not a measurement
+  error.
+
+Both series are still useful as trends: decode J/token falling as KV-cache hit
+rate improves, or prefill J/token rising with longer prompts, are real signals.
+Track each role against itself over time rather than reading the prefill/decode
+ratio as a hardware efficiency ratio.
+
+If prefill nodes report zero output tokens in a window, that window counts as
+idle and is not aggregated — the node's energy then shows up in
+`aitra_idle_power_watts` instead. Check `aitra_gpu_serving_utilization_ratio`
+for the prefill nodes if the prefill series is missing.
+
+## Grafana panel: latency and energy side by side
+
+Import [`examples/grafana/llmd-prefill-decode.json`](../../examples/grafana/llmd-prefill-decode.json).
+It shows, per role:
+
+- J/token from Aitra Meter (`aitra_j_per_token` split by `role`)
+- Time per output token from vLLM's own histogram
+  (`vllm:time_per_output_token_seconds`), which llm-d's monitoring stack
+  already scrapes
+
+The pairing connects inference efficiency (latency) to infrastructure
+efficiency (energy) in one view.
+
+Useful queries:
+
+```promql
+# Per-phase J/token by model
+avg by (model, role) (aitra_j_per_token{role=~"prefill|decode"})
+
+# Decode-pool efficiency trend (lower is better)
+avg by (model) (aitra_j_per_token{role="decode"})
+
+# vLLM decode latency for the same split (llm-d metrics, not Aitra Meter)
+histogram_quantile(0.9,
+  sum by (le) (rate(vllm:time_per_output_token_seconds_bucket[5m])))
+```
+
+## Verify
+
+```bash
+# 1. Pods carry the role label
+kubectl get pods -A -L llm-d.ai/role,llm-d.ai/model | grep -E 'prefill|decode'
+
+# 2. The role label reaches Prometheus
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+# Query: aitra_j_per_token{role=~"prefill|decode"}
+```
+
+If the series appear without a `role` label, the pod lookup matched a
+different pod on the node — see the multi-model section above, or check that
+the llm-d pods are Running on the nodes where the measurement agent reports.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -94,6 +94,7 @@ Metrics are exposed at:
 | `precision` | Precision from pod annotation: `fp16`, `fp8`, `bf16`, `unknown` |
 | `calibration_tier` | `aitra_benchmark`, `reference`, `self_calibrated`, `uncalibrated` |
 | `attribution_method` | `direct` or `proportional` |
+| `role` | llm-d serving phase from the `llm-d.ai/role` pod label: `prefill` or `decode`. Empty (label absent) for conventional serving — the dimension adds no cardinality outside llm-d disaggregated deployments. See the [llm-d integration guide](../guides/llm-d-integration.md). |
 
 ---
 
@@ -325,4 +326,9 @@ increase(aitra_namespace_tokens_total[30d])
 **Nodes with high idle ratio:**
 ```promql
 aitra_idle_time_ratio > 0.5
+```
+
+**Prefill vs decode J/token (llm-d disaggregated serving):**
+```promql
+avg by (model, role) (aitra_j_per_token{role=~"prefill|decode"})
 ```

--- a/examples/grafana/llmd-prefill-decode.json
+++ b/examples/grafana/llmd-prefill-decode.json
@@ -1,0 +1,60 @@
+{
+  "title": "llm-d + Aitra Meter — Prefill vs decode",
+  "description": "Per-phase energy (Aitra Meter) next to per-phase latency (vLLM/llm-d) for disaggregated serving. The role label comes from the llm-d.ai/role pod label. Note: prefill instances report few output tokens, so prefill J/token reads as joules of prefill per request rather than a per-generated-token cost — compare each role against itself over time, not against the other.",
+  "tags": ["aitra-meter", "llm-d", "energy", "inference"],
+  "panels": [
+    {
+      "title": "J/token by serving phase (Aitra Meter)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "avg by (model, role) (aitra_j_per_token{role=~\"prefill|decode\"})",
+          "legendFormat": "{{model}} — {{role}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "joule" } },
+      "description": "Source: Aitra Meter. Separate series per llm-d.ai/role. Decode J/token is comparable to conventional serving; prefill instances report few output tokens, so prefill J/token is closer to joules of prefill per request — read it as a per-phase trend."
+    },
+    {
+      "title": "Time per output token (vLLM, scraped by llm-d monitoring)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.9, sum by (le, model_name) (rate(vllm:time_per_output_token_seconds_bucket[5m])))",
+          "legendFormat": "{{model_name}} — p90 TPOT"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "description": "Source: vLLM /metrics (already scraped by llm-d's monitoring stack). Pair with the energy panel: latency is what the serving stack delivers, J/token is what the infrastructure spends."
+    },
+    {
+      "title": "Decode-pool efficiency trend",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "avg by (model) (aitra_j_per_token{role=\"decode\"})",
+          "legendFormat": "{{model}} — decode J/token"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "joule" } },
+      "description": "Lower is better. Falling decode J/token as KV-cache hit rate improves is the signal disaggregated serving makes measurable."
+    },
+    {
+      "title": "Prefill-node serving utilization",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "aitra_gpu_serving_utilization_ratio",
+          "legendFormat": "{{node}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "description": "If the prefill J/token series is missing, check here: windows with zero reported output tokens count as idle and are not aggregated."
+    }
+  ],
+  "schemaVersion": 38
+}

--- a/internal/aggregation/attribution.go
+++ b/internal/aggregation/attribution.go
@@ -22,6 +22,12 @@ type PodMeta struct {
 	Precision  string // annotation aitra-ai.github.io/precision, or "unknown"
 	Team       string // annotation aitra-ai.github.io/team, or ""
 	CostCentre string // annotation aitra-ai.github.io/cost-centre, or ""
+
+	// Role is the serving phase for disaggregated inference, read from the
+	// llm-d.ai/role pod label ("prefill" | "decode"). Empty for conventional
+	// (non-disaggregated) serving; an empty value is dropped by Prometheus,
+	// so the role dimension adds no cardinality outside llm-d deployments.
+	Role string
 }
 
 // PodLookup is the interface the Resolver uses to fetch pod metadata from

--- a/internal/aggregation/attribution_test.go
+++ b/internal/aggregation/attribution_test.go
@@ -45,6 +45,41 @@ func TestResolverDirect(t *testing.T) {
 	}
 }
 
+func TestResolverRolePassthrough(t *testing.T) {
+	// The llm-d.ai/role label ("prefill" | "decode") resolved by the pod
+	// lookup must pass through Resolve unchanged (issue #49).
+	tests := []struct {
+		name string
+		role string
+	}{
+		{name: "prefill", role: "prefill"},
+		{name: "decode", role: "decode"},
+		{name: "no role for conventional serving", role: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lookup := &stubLookup{pods: map[string]PodMeta{
+				"node-1/qwen": {Namespace: "inference-prod", Role: tc.role},
+			}}
+			r := NewResolver(lookup, PolicyConfig{DefaultMethod: AttributionDirect})
+			a := r.Resolve(context.Background(), "node-1", "qwen")
+			if a.Role != tc.role {
+				t.Errorf("Role = %q, want %q", a.Role, tc.role)
+			}
+		})
+	}
+}
+
+func TestResolverRoleEmptyOnLookupError(t *testing.T) {
+	// The best-effort fallback attribution must not invent a role.
+	lookup := &stubLookup{err: errors.New("k8s unavailable")}
+	r := NewResolver(lookup, PolicyConfig{})
+	a := r.Resolve(context.Background(), "node-1", "qwen")
+	if a.Role != "" {
+		t.Errorf("Role = %q on lookup error, want empty", a.Role)
+	}
+}
+
 func TestResolverNamespaceOverride(t *testing.T) {
 	lookup := &stubLookup{pods: map[string]PodMeta{
 		"node-1/llama": {Namespace: "inference-shared"},

--- a/internal/aggregation/loop.go
+++ b/internal/aggregation/loop.go
@@ -125,7 +125,7 @@ func (l *Loop) ReportWindow(
 
 	metrics.JPerToken.WithLabelValues(
 		attr.Namespace, attr.Workload, w.ModelName, hw,
-		attr.Precision, tier, method,
+		attr.Precision, tier, method, attr.Role,
 	).Set(jpt)
 
 	if jpt > 0 {

--- a/internal/aggregation/loop_test.go
+++ b/internal/aggregation/loop_test.go
@@ -120,6 +120,46 @@ func TestLoopJPerTokenArithmetic(t *testing.T) {
 	}
 }
 
+// TestLoopJPerTokenRoleLabel checks the llm-d serving phase resolved from the
+// pod's llm-d.ai/role label reaches the aitra_j_per_token role label, so
+// prefill and decode J/token become separate series (issue #49). Pods without
+// the label produce role="", which Prometheus treats as an absent label.
+func TestLoopJPerTokenRoleLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string // unique per case: gauge children are process-global
+		role  string
+	}{
+		{name: "prefill", model: "role-model-prefill", role: "prefill"},
+		{name: "decode", model: "role-model-decode", role: "decode"},
+		{name: "conventional serving", model: "role-model-none", role: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			loop, _ := newTestLoop(
+				map[string]PodMeta{"node-1/" + tc.model: {
+					Namespace: "prod", Workload: "chat", Precision: "fp16", Role: tc.role,
+				}},
+				PolicyConfig{DefaultMethod: AttributionDirect},
+				nil,
+			)
+			w := baseReport()
+			w.ModelName = tc.model
+			if _, err := loop.ReportWindow(context.Background(), w); err != nil {
+				t.Fatalf("ReportWindow: %v", err)
+			}
+			got := testutil.ToFloat64(metrics.JPerToken.WithLabelValues(
+				"prod", "chat", tc.model, "h100", "fp16",
+				string(TierUncalibrated), string(AttributionDirect), tc.role,
+			))
+			want := 412.4 / 1328.0
+			if math.Abs(got-want) > 1e-9 {
+				t.Errorf("j_per_token{role=%q} = %v, want %v", tc.role, got, want)
+			}
+		})
+	}
+}
+
 // TestLoopModelTokensTotalAccumulates checks the model-level token counter is
 // monotonic across windows. A unique model label isolates this counter child
 // from other tests (Prometheus counters are process-global and never reset).

--- a/internal/k8s/k8s_test.go
+++ b/internal/k8s/k8s_test.go
@@ -151,6 +151,138 @@ func TestPodMetaLookupMissingAnnotationsFallback(t *testing.T) {
 	}
 }
 
+// --- llm-d labels (issue #49) -------------------------------------------------
+
+func TestPodMetaLookupLLMDRole(t *testing.T) {
+	// The llm-d.ai/role label is read into PodMeta.Role.
+	for _, role := range []string{"prefill", "decode"} {
+		t.Run(role, func(t *testing.T) {
+			client := fake.NewSimpleClientset(
+				makePod("llm-d-0", "inference-prod", "node-1", corev1.PodRunning,
+					map[string]string{labelLLMDRole: role, labelLLMDModel: "qwen3-32b"},
+					nil),
+			)
+			meta, err := NewPodMetaLookup(client).ByNodeAndModel(context.Background(), "node-1", "Qwen/Qwen3-32B")
+			if err != nil {
+				t.Fatalf("ByNodeAndModel: %v", err)
+			}
+			if meta.Role != role {
+				t.Errorf("Role = %q, want %q", meta.Role, role)
+			}
+		})
+	}
+}
+
+func TestPodMetaLookupRoleEmptyWithoutLabel(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		makePod("vllm-0", "prod", "node-1", corev1.PodRunning, nil, nil),
+	)
+	meta, err := NewPodMetaLookup(client).ByNodeAndModel(context.Background(), "node-1", "m")
+	if err != nil {
+		t.Fatalf("ByNodeAndModel: %v", err)
+	}
+	if meta.Role != "" {
+		t.Errorf("Role = %q for pod without llm-d.ai/role, want empty", meta.Role)
+	}
+}
+
+func TestPodMetaLookupPrefersLLMDModelMatch(t *testing.T) {
+	// With two llm-d pods on the same node serving different models, the pod
+	// whose llm-d.ai/model matches the reported model name wins — even when a
+	// non-matching candidate is listed first.
+	client := fake.NewSimpleClientset(
+		makePod("a-other", "prod", "node-1", corev1.PodRunning,
+			map[string]string{labelLLMDModel: "llama-3-8b", labelLLMDRole: "decode"}, nil),
+		makePod("b-match", "prod", "node-1", corev1.PodRunning,
+			map[string]string{labelLLMDModel: "qwen3-32b", labelLLMDRole: "prefill"}, nil),
+	)
+	meta, err := NewPodMetaLookup(client).ByNodeAndModel(context.Background(), "node-1", "Qwen/Qwen3-32B")
+	if err != nil {
+		t.Fatalf("ByNodeAndModel: %v", err)
+	}
+	if meta.Role != "prefill" {
+		t.Errorf("Role = %q, want prefill from the llm-d.ai/model-matching pod", meta.Role)
+	}
+}
+
+func TestPodMetaLookupLLMDModelNeverExcludes(t *testing.T) {
+	// A non-matching llm-d.ai/model must not exclude the pod: llm-d
+	// ModelService names rarely equal the served model name, and dropping the
+	// pod would regress attribution to namespace="unknown".
+	client := fake.NewSimpleClientset(
+		makePod("llm-d-0", "inference-prod", "node-1", corev1.PodRunning,
+			map[string]string{labelLLMDModel: "my-service", labelLLMDRole: "decode"}, nil),
+	)
+	meta, err := NewPodMetaLookup(client).ByNodeAndModel(context.Background(), "node-1", "Qwen/Qwen3-32B")
+	if err != nil {
+		t.Fatalf("ByNodeAndModel: %v", err)
+	}
+	if meta.Namespace != "inference-prod" {
+		t.Errorf("Namespace = %q, want inference-prod (fallback candidate)", meta.Namespace)
+	}
+	if meta.Role != "decode" {
+		t.Errorf("Role = %q, want decode", meta.Role)
+	}
+}
+
+func TestPodMetaLookupAitraLabelBeatsLLMDHint(t *testing.T) {
+	// The explicit aitra-ai.github.io/model-name label stays authoritative:
+	// a pod with a matching aitra label is selected over an earlier pod whose
+	// llm-d.ai/model does not match.
+	client := fake.NewSimpleClientset(
+		makePod("a-llmd", "ns-a", "node-1", corev1.PodRunning,
+			map[string]string{labelLLMDModel: "other-model"}, nil),
+		makePod("b-aitra", "ns-b", "node-1", corev1.PodRunning,
+			map[string]string{labelModelName: "llama"}, nil),
+	)
+	meta, err := NewPodMetaLookup(client).ByNodeAndModel(context.Background(), "node-1", "llama")
+	if err != nil {
+		t.Fatalf("ByNodeAndModel: %v", err)
+	}
+	if meta.Namespace != "ns-b" {
+		t.Errorf("Namespace = %q, want ns-b (exact aitra model-name match)", meta.Namespace)
+	}
+}
+
+func TestLLMDModelMatches(t *testing.T) {
+	tests := []struct {
+		name       string
+		labelValue string
+		modelName  string
+		want       bool
+	}{
+		{"exact", "qwen3-32b", "qwen3-32b", true},
+		{"sanitized full name", "qwen-qwen3-32b", "Qwen/Qwen3-32B", true},
+		{"sanitized basename", "qwen3-32b", "Qwen/Qwen3-32B", true},
+		{"case-insensitive label", "Qwen3-32B", "qwen3-32b", true},
+		{"dots preserved", "llama-3.1-8b-instruct", "meta-llama/Llama-3.1-8B-Instruct", true},
+		{"different model", "llama-3-8b", "Qwen/Qwen3-32B", false},
+		{"empty label", "", "Qwen/Qwen3-32B", false},
+		{"empty model", "qwen3-32b", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := llmdModelMatches(tc.labelValue, tc.modelName); got != tc.want {
+				t.Errorf("llmdModelMatches(%q, %q) = %v, want %v", tc.labelValue, tc.modelName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeModelName(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"Qwen/Qwen3-32B", "qwen-qwen3-32b"},
+		{"meta-llama/Llama-3.1-8B-Instruct", "meta-llama-llama-3.1-8b-instruct"},
+		{"already-valid_name.v2", "already-valid_name.v2"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := sanitizeModelName(tc.in); got != tc.want {
+			t.Errorf("sanitizeModelName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // --- annotOr ----------------------------------------------------------------
 
 func TestAnnotOrFallback(t *testing.T) {

--- a/internal/k8s/podmeta.go
+++ b/internal/k8s/podmeta.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +25,12 @@ const (
 	// labelModelName is set on pods by the measurement agent (or cluster operator)
 	// to match pods to the model they serve.
 	labelModelName = "aitra-ai.github.io/model-name"
+
+	// llm-d (https://llm-d.ai) labels its inference pods with the serving phase
+	// and model. Aitra Meter reads both so disaggregated prefill/decode
+	// deployments get per-phase attribution with no llm-d-side changes.
+	labelLLMDRole  = "llm-d.ai/role"  // "prefill" | "decode"
+	labelLLMDModel = "llm-d.ai/model" // ModelService name, a DNS-1123 label
 )
 
 // ErrNoPod is returned when no matching pod is found for a (node, model) pair.
@@ -42,9 +49,18 @@ func NewPodMetaLookup(client kubernetes.Interface) *PodMetaLookup {
 	return &PodMetaLookup{client: client}
 }
 
-// ByNodeAndModel finds the first Running pod on node serving modelName, then
-// extracts namespace and Aitra annotations. Pods without the model label match
-// any model (useful for single-model deployments).
+// ByNodeAndModel finds a Running pod on node serving modelName, then extracts
+// namespace, Aitra annotations, and llm-d labels. Selection order:
+//
+//  1. A pod whose aitra-ai.github.io/model-name label equals modelName, or
+//     whose llm-d.ai/model label matches it (see llmdModelMatches).
+//  2. Otherwise, the first candidate pod: one with no aitra-ai.github.io/model-name
+//     label, matching any model (useful for single-model deployments), or with
+//     a label equal to modelName.
+//
+// The llm-d.ai/model label is only ever a positive match hint — a pod is never
+// excluded because of it, since llm-d ModelService names rarely equal the model
+// name the inference server reports (label values cannot contain "/").
 func (p *PodMetaLookup) ByNodeAndModel(ctx context.Context, node, modelName string) (aggregation.PodMeta, error) {
 	list, err := p.client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 		FieldSelector: "spec.nodeName=" + node + ",status.phase=Running",
@@ -52,6 +68,7 @@ func (p *PodMetaLookup) ByNodeAndModel(ctx context.Context, node, modelName stri
 	if err != nil {
 		return aggregation.PodMeta{}, fmt.Errorf("list pods on %s: %w", node, err)
 	}
+	var fallback *corev1.Pod
 	for i := range list.Items {
 		pod := &list.Items[i]
 		// Always filter client-side — FieldSelector is a server hint, not a guarantee
@@ -62,12 +79,59 @@ func (p *PodMetaLookup) ByNodeAndModel(ctx context.Context, node, modelName stri
 		if pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
-		if ml := pod.Labels[labelModelName]; ml != "" && ml != modelName {
+		ml := pod.Labels[labelModelName]
+		if ml != "" && ml != modelName {
 			continue
 		}
-		return podToMeta(pod), nil
+		if ml == modelName || llmdModelMatches(pod.Labels[labelLLMDModel], modelName) {
+			return podToMeta(pod), nil
+		}
+		if fallback == nil {
+			fallback = pod
+		}
+	}
+	if fallback != nil {
+		return podToMeta(fallback), nil
 	}
 	return aggregation.PodMeta{}, ErrNoPod
+}
+
+// llmdModelMatches reports whether an llm-d.ai/model label value refers to
+// modelName. Label values cannot contain "/", so llm-d deployments name the
+// ModelService after the model in DNS-1123 form (e.g. "qwen3-32b" for
+// "Qwen/Qwen3-32B"). The comparison therefore also tries the sanitized full
+// model name and its path basename.
+func llmdModelMatches(labelValue, modelName string) bool {
+	if labelValue == "" || modelName == "" {
+		return false
+	}
+	if labelValue == modelName {
+		return true
+	}
+	lv := strings.ToLower(labelValue)
+	if lv == sanitizeModelName(modelName) {
+		return true
+	}
+	if idx := strings.LastIndex(modelName, "/"); idx >= 0 {
+		return lv == sanitizeModelName(modelName[idx+1:])
+	}
+	return false
+}
+
+// sanitizeModelName lowercases s and replaces every character that is not
+// valid in a Kubernetes label value ([a-z0-9-._]) with "-".
+func sanitizeModelName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '.', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
 }
 
 func podToMeta(pod *corev1.Pod) aggregation.PodMeta {
@@ -78,6 +142,7 @@ func podToMeta(pod *corev1.Pod) aggregation.PodMeta {
 		Precision:  annotOr(ann, annotPrecision, "unknown"),
 		Team:       ann[annotTeam],
 		CostCentre: ann[annotCostCentre],
+		Role:       pod.Labels[labelLLMDRole],
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,10 +9,14 @@ import (
 
 var (
 	// JPerToken is the primary Aitra Meter metric.
+	// The role label is the llm-d serving phase ("prefill" | "decode") for
+	// disaggregated deployments. It is empty — and therefore absent after
+	// Prometheus ingestion — for conventional serving, so it adds no
+	// cardinality outside llm-d clusters.
 	JPerToken = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "aitra_j_per_token",
 		Help: "Joules per output token for the current measurement window.",
-	}, []string{"namespace", "workload", "model", "hardware", "precision", "calibration_tier", "attribution_method"})
+	}, []string{"namespace", "workload", "model", "hardware", "precision", "calibration_tier", "attribution_method", "role"})
 
 	// ClusterJPerToken is the cluster-wide aggregate J/token.
 	ClusterJPerToken = promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
Closes #49.

- Attribution resolver reads the llm-d.ai/role pod label (prefill|decode) and propagates it as a new optional 'role' label on aitra_j_per_token (empty when unset — no cardinality impact for non-llm-d clusters); llm-d.ai/model used as a match hint
- Resolver unit tests; CHANGELOG entry (review fix)
- docs/guides/llm-d-integration.md + examples/grafana/llmd-prefill-decode.json for prefill-vs-decode comparison

Out of scope (outreach, noted in issue): filing the llm-d/llm-d issue and contributing panels to llm-d-prism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)