### PR TITLE
feat(mig): per-slice MIG energy attribution and J/token (closes #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidance.
 - [Configuration reference](docs/reference/configuration.md) — all Helm values and CRD fields
 - [HTTP API reference](docs/reference/api.md) — aggregation service API
 - [Compatibility](docs/reference/compatibility.md) — provider × hardware × inference server matrix
+- [MIG support](docs/reference/mig-support.md) — per-slice energy attribution on MIG-partitioned GPUs
 - [Glossary](docs/reference/glossary.md)
 
 ### Design

--- a/cmd/measurement-agent/main.go
+++ b/cmd/measurement-agent/main.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 
 	"github.com/aitra-ai/aitra-meter/internal/agent"
@@ -29,6 +32,11 @@ func main() {
 	windowSecs := flag.Int("window-seconds", 30, "Measurement window duration in seconds")
 	logLevel := flag.String("log-level", "info", "Log level: debug | info | warn | error")
 	inferenceEndpoint := flag.String("inference-endpoint", "", "Inference provider metrics URL (e.g. http://localhost:8000/metrics)")
+	metricsAddr := flag.String("metrics-addr", ":9090", "Address for the agent's Prometheus /metrics and health endpoints (empty to disable)")
+	migInstance := flag.String("mig-instance", "", "MIG slice the node's inference server is pinned to, as a mig_instance label (mig-1g.10gb:0) or MIG device UUID (MIG-…). Empty: auto when the node exposes exactly one slice")
+	migNamespace := flag.String("mig-namespace", "", "Namespace label for aitra_mig_* metrics (default \"unknown\")")
+	migTeam := flag.String("mig-team", "", "Team label for aitra_mig_cost_usd_total (default \"unknown\")")
+	electricityCost := flag.Float64("electricity-cost-usd-per-kwh", 0, "Electricity price in USD/kWh for aitra_mig_cost_usd_total; 0 disables the cost counter")
 	flag.Parse()
 
 	log := newLogger(*logLevel)
@@ -58,6 +66,26 @@ func main() {
 		)
 	}
 
+	// MIG detection (issue #43): when the energy provider reports MIG mode,
+	// the loop switches to MIG-aware windows automatically. This log makes
+	// the switch visible at startup.
+	if migp, ok := energyProvider.(provider.MIGEnergyProvider); ok && migp.MIGEnabled() {
+		slices, serr := migp.MIGSlices(context.Background())
+		if serr != nil {
+			log.Warn("MIG mode detected but slice enumeration failed", zap.Error(serr))
+		} else {
+			instances := make([]string, 0, len(slices))
+			for _, s := range slices {
+				instances = append(instances, s.Instance)
+			}
+			log.Info("MIG mode detected — per-slice energy attribution enabled",
+				zap.Int("slice_count", len(slices)),
+				zap.Strings("mig_instances", instances),
+				zap.String("pinned_instance", *migInstance),
+			)
+		}
+	}
+
 	inferenceConfig := map[string]string{}
 	if *inferenceEndpoint != "" {
 		inferenceConfig["endpoint"] = *inferenceEndpoint
@@ -70,12 +98,39 @@ func main() {
 		)
 	}
 
+	// Agent-local Prometheus metrics (aitra_mig_* on MIG nodes) + health probes.
+	if *metricsAddr != "" {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		})
+		mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ready"}`))
+		})
+		srv := &http.Server{Addr: *metricsAddr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+		go func() {
+			log.Info("metrics server listening", zap.String("addr", *metricsAddr))
+			if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Error("metrics server stopped", zap.Error(err))
+			}
+		}()
+	}
+
 	loop, err := agent.New(agent.Config{
 		Node:              node,
 		AggregatorAddr:    *aggregatorAddr,
 		WindowDuration:    time.Duration(*windowSecs) * time.Second,
 		EnergyProvider:    energyProvider,
 		InferenceProvider: inferenceProvider,
+		MIG: agent.MIGAttribution{
+			PinnedInstance:        *migInstance,
+			Namespace:             *migNamespace,
+			Team:                  *migTeam,
+			ElectricityCostPerKWh: *electricityCost,
+		},
 	}, log)
 	if err != nil {
 		log.Fatal("agent init failed", zap.Error(err))

--- a/docs/guides/energy-providers.md
+++ b/docs/guides/energy-providers.md
@@ -22,6 +22,14 @@ newer (V100, T4, A100, H100, H200, L40S, B200). For each measurement window,
 the provider records the counter value at window start and end; the delta is
 the energy consumed during that window.
 
+**MIG:** on GPUs partitioned with MIG (A100, A30, H100, H200, B200), the
+provider detects MIG mode at startup and additionally attributes each window's
+energy to individual MIG slices, exposed as the `aitra_mig_*` metrics on the
+agent's `:9090/metrics` endpoint. Per-slice energy is attributed
+proportionally (there is no per-slice energy sensor), and the feature has not
+yet been validated on MIG hardware — see
+[MIG support](../reference/mig-support.md) for the model and limitations.
+
 **Helm:**
 
 ```yaml

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -30,7 +30,18 @@ Complete reference for all Helm values, CRD fields, and pod annotations.
 | `measurementAgent.inferenceProvider.config.endpoint` | string | `http://localhost:8000/metrics` | Inference server metrics endpoint |
 | `measurementAgent.cvThreshold` | float | `0.03` | CV gate threshold. Measurements with rolling CV above this are flagged `unstable` |
 | `measurementAgent.cvWindowSize` | int | `100` | Number of windows in the rolling CV calculation |
+| `measurementAgent.mig.pinnedInstance` | string | `""` | MIG slice the node's inference server is pinned to, as a `mig_instance` label (`mig-1g.10gb:0`) or MIG device UUID (`MIG-…`, the pod's `CUDA_VISIBLE_DEVICES` value). Empty: auto-pin when the node exposes exactly one slice |
+| `measurementAgent.mig.namespace` | string | `""` | `namespace` label on `aitra_mig_*` token/cost metrics (`unknown` when empty) |
+| `measurementAgent.mig.team` | string | `""` | `team` label on `aitra_mig_cost_usd_total` (`unknown` when empty) |
+| `measurementAgent.mig.electricityCostUSDPerKWh` | float | `0` | Electricity price in USD/kWh for `aitra_mig_cost_usd_total`. `0` disables the cost counter |
 | `measurementAgent.logLevel` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
+
+MIG mode itself is detected automatically at startup (`nvml` energy provider only);
+the `measurementAgent.mig.*` values map to the agent flags `--mig-instance`,
+`--mig-namespace`, `--mig-team`, and `--electricity-cost-usd-per-kwh`. The agent
+serves its own Prometheus `/metrics` and health endpoints on `--metrics-addr`
+(default `:9090`; empty disables). See
+[MIG support — Configuration](mig-support.md#configuration).
 
 ### `aggregationService`
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -77,6 +77,65 @@ Metrics are exposed at:
 
 ---
 
+### MIG attribution metrics (#43)
+
+Exposed by the measurement agent on nodes where MIG mode is detected
+(`nvml` energy provider only). Per-slice energy is **attributed** — the
+parent GPU's measured energy split by compute-slice fraction — not measured
+per slice; see [MIG support](mig-support.md) for the model, its limitations,
+and the (pending) hardware validation status.
+
+Shared labels: `node` (Kubernetes node name), `gpu_uuid` (UUID of the parent
+physical GPU), `mig_instance` (DCGM-style slice label, e.g. `mig-1g.10gb:0`).
+
+### `aitra_mig_j_per_token`
+
+**Type:** Gauge  
+**Source:** Measurement agent  
+**Description:** Joules per output token for the pinned MIG slice over the last measurement window.
+
+| Label | Description |
+|---|---|
+| `node`, `gpu_uuid`, `mig_instance` | See above |
+| `namespace` | Namespace of the pinned inference pod (`--mig-namespace`, default `unknown`) |
+| `model` | Model name from the inference provider |
+
+---
+
+### `aitra_mig_tokens_total`
+
+**Type:** Counter  
+**Source:** Measurement agent  
+**Description:** Cumulative output tokens attributed to a MIG slice. Same labels as `aitra_mig_j_per_token`.
+
+---
+
+### `aitra_mig_cost_usd_total`
+
+**Type:** Counter  
+**Source:** Measurement agent  
+**Description:** Cumulative energy cost in USD attributed to a MIG slice. Absent unless the agent is started with `--electricity-cost-usd-per-kwh > 0`.
+
+| Label | Description |
+|---|---|
+| `node`, `gpu_uuid`, `mig_instance` | See above |
+| `namespace` | Namespace label (default `unknown`) |
+| `team` | Team label (`--mig-team`, default `unknown`) |
+
+---
+
+### `aitra_mig_power_watts`
+
+**Type:** Gauge  
+**Source:** Measurement agent  
+**Description:** Power in watts attributed to a MIG slice: parent GPU window energy split by compute-slice fraction, divided by window duration. Recorded for every slice, pinned or not.
+
+| Label | Description |
+|---|---|
+| `node`, `gpu_uuid`, `mig_instance` | See above |
+
+---
+
 ## Aggregation service metrics
 
 ### `aitra_j_per_token`

--- a/docs/reference/mig-support.md
+++ b/docs/reference/mig-support.md
@@ -1,0 +1,223 @@
+# MIG support
+
+Aitra Meter can attribute GPU energy — and, when an inference server is
+pinned to a slice, output tokens and J/token — to individual MIG
+(Multi-Instance GPU) slices on NVIDIA GPUs. This page documents the
+attribution model, its limitations, and how to configure it.
+
+**Validation status: not yet validated on MIG hardware.** The attribution
+logic is unit-tested against a mocked NVML interface. The integration test on
+an A100/H100 in MIG mode (issue #43 acceptance criterion) is still pending
+lab hardware. Until that has run, treat per-slice numbers as unverified.
+
+---
+
+## Requirements
+
+| Requirement | Detail |
+|---|---|
+| GPU | MIG-capable NVIDIA GPU: A100, A30, H100, H200, B200 |
+| Driver | R450.80.02 or newer (NVML 11.0 — first version with the MIG device APIs) |
+| Energy provider | `nvml` (in-process NVML). The `dcgm` and `zeus` providers do not feed per-slice attribution |
+| Metrics scrape | The `aitra_mig_*` metrics are exposed by the **measurement agent** (`:9090/metrics`, `--metrics-addr`), not the aggregation service |
+
+## Detection
+
+At startup the `nvml` energy provider calls `nvmlDeviceGetMigMode` on every
+GPU. If at least one GPU has MIG mode enabled, the agent switches to
+MIG-aware measurement windows automatically and logs:
+
+```
+MIG mode detected — per-slice energy attribution enabled
+```
+
+No configuration is required for detection. GPUs that predate MIG or have it
+disabled are measured exactly as before; on mixed nodes only the MIG-enabled
+GPUs contribute per-slice series.
+
+MIG geometry is re-read at the start of every measurement window, so slices
+created or destroyed at runtime are picked up within one window (default 30 s).
+
+## Attribution model
+
+### Energy
+
+There is no per-slice energy sensor. A100/H100 boards have board-level power
+rails, so `nvmlDeviceGetTotalEnergyConsumption` is meaningful on the physical
+GPU handle, not per MIG instance. Aitra Meter therefore **attributes** energy
+to slices; it does not measure it per slice:
+
+1. Each measurement window reads the parent GPU's hardware energy counter at
+   window start and end. The delta is the parent's measured energy.
+2. The delta is split across the parent's slices in proportion to their
+   compute slice count (NVML `GpuInstanceSliceCount`):
+
+   ```
+   slice_joules = parent_joules × slice_compute_slices / Σ compute_slices of all slices on that parent
+   ```
+
+3. `aitra_mig_power_watts` is `slice_joules / window_seconds`.
+
+Properties and consequences of this model:
+
+- **Energy is conserved.** Per-slice values on a parent always sum to the
+  parent's measured delta. On a partially partitioned GPU (say 3 × 1g on an
+  A100 with capacity for 7), the whole measured board energy — including the
+  idle share of the unpartitioned capacity — is spread over the 3 existing
+  slices. Nothing is left unattributed.
+- **The split is static, not activity-based.** A busy 1g slice and an idle 1g
+  slice on the same GPU are attributed the same energy. Activity-weighted
+  attribution (e.g. by DCGM SM activity per instance) is a possible follow-up,
+  not implemented.
+- If slice attributes cannot be read for any slice on a parent, the parent's
+  energy is split equally across its slices rather than dropped.
+- If a parent's energy counter cannot be read for a window, that parent's
+  slices are absent from that window's attribution (the node-total metrics
+  are unaffected).
+
+### Tokens and J/token
+
+vLLM does not expose per-MIG token counts. The supported scope is **one
+inference server pinned to one slice** via `CUDA_VISIBLE_DEVICES=MIG-<uuid>`
+on the inference pod:
+
+- All output tokens read from the node's inference provider are attributed to
+  the pinned slice.
+- The pinned slice is named to the agent with `--mig-instance`, either as the
+  `mig_instance` label value (`mig-1g.10gb:0`) or the MIG device UUID
+  (`MIG-…`, the same value as the pod's `CUDA_VISIBLE_DEVICES`).
+- If `--mig-instance` is not set and the node exposes **exactly one** slice,
+  tokens are attributed to it automatically. With several slices and no pin,
+  token metrics stay absent (power attribution still works) — guessing would
+  produce wrong numbers.
+
+True multi-tenant MIG — several inference servers on one GPU, one per slice —
+requires pod-to-MIG-device mapping (GPU Operator device-plugin allocations or
+DCGM pod mapping) and is out of scope here; see issue #43 feasibility notes.
+
+## Metrics
+
+All four are exposed by the measurement agent. `gpu_uuid` is the UUID of the
+**parent** physical GPU; `mig_instance` identifies the slice within it.
+
+### `aitra_mig_j_per_token`
+
+**Type:** Gauge  
+**Description:** Joules per output token for the pinned MIG slice over the
+last measurement window. `slice_joules / token_delta`.
+
+| Label | Description |
+|---|---|
+| `node` | Kubernetes node name |
+| `gpu_uuid` | Parent GPU UUID |
+| `mig_instance` | Slice label, e.g. `mig-1g.10gb:0` |
+| `namespace` | Namespace of the pinned inference pod (`--mig-namespace`, default `unknown`) |
+| `model` | Model name from the inference provider |
+
+### `aitra_mig_tokens_total`
+
+**Type:** Counter  
+**Description:** Cumulative output tokens attributed to a MIG slice.
+Same labels as `aitra_mig_j_per_token`.
+
+### `aitra_mig_cost_usd_total`
+
+**Type:** Counter  
+**Description:** Cumulative energy cost in USD attributed to a MIG slice:
+`slice_joules / 3.6e6 × $/kWh` per window. Absent unless the agent is started
+with `--electricity-cost-usd-per-kwh > 0`.
+
+| Label | Description |
+|---|---|
+| `node` | Kubernetes node name |
+| `gpu_uuid` | Parent GPU UUID |
+| `mig_instance` | Slice label |
+| `namespace` | Namespace label (default `unknown`) |
+| `team` | Team label (`--mig-team`, default `unknown`) |
+
+### `aitra_mig_power_watts`
+
+**Type:** Gauge  
+**Description:** Power attributed to a MIG slice: the parent GPU's window
+energy split by compute-slice fraction, divided by the window duration.
+Recorded for **every** slice, pinned or not.
+
+| Label | Description |
+|---|---|
+| `node` | Kubernetes node name |
+| `gpu_uuid` | Parent GPU UUID |
+| `mig_instance` | Slice label |
+
+## Label conventions
+
+`mig_instance` is `mig-<profile>:<index>`, e.g. `mig-1g.10gb:0`,
+`mig-2g.20gb:1`:
+
+- `<profile>` is derived from NVML attributes as
+  `<GpuInstanceSliceCount>g.<ceil(MemorySizeMB / 1024)>gb`. NVML reports the
+  usable framebuffer, which sits slightly below the nominal profile size
+  (e.g. 9728 MiB for `1g.10gb`), so rounding up recovers the nominal name for
+  every A100/H100 profile we are aware of. This derivation has not been
+  verified on hardware; if a name comes out wrong for some profile, the label
+  is still stable and unique per slice — please file an issue.
+- `<index>` is the MIG device index within the parent GPU in NVML enumeration
+  order — the order `nvidia-smi -L` lists them. It is **not** the GPU
+  instance ID that DCGM exposes as `GPU_I_ID` (those are not sequential:
+  1g instances on an A100 get IDs 7–13). A slice is globally identified by
+  the `(gpu_uuid, mig_instance)` pair.
+
+## Configuration
+
+Agent flags (all optional — detection itself needs none):
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--mig-instance` | `""` | Slice the inference server is pinned to (`mig-1g.10gb:0` or `MIG-<uuid>`). Empty: auto when exactly one slice |
+| `--mig-namespace` | `unknown` | `namespace` label on token/cost metrics |
+| `--mig-team` | `unknown` | `team` label on the cost counter |
+| `--electricity-cost-usd-per-kwh` | `0` | Enables `aitra_mig_cost_usd_total` |
+| `--metrics-addr` | `:9090` | Where the agent serves `/metrics` (empty disables) |
+
+Helm:
+
+```yaml
+measurementAgent:
+  energyProvider:
+    type: nvml
+  mig:
+    pinnedInstance: "mig-1g.10gb:0"
+    namespace: "tenant-a"
+    team: "ml-platform"
+    electricityCostUSDPerKWh: 0.20
+```
+
+## Coexistence with DCGM Exporter
+
+Aitra Meter only issues read-only NVML queries (`GetMigMode`, MIG device
+enumeration, energy/power counters). It takes no exclusive locks and does not
+reconfigure MIG, so DCGM Exporter keeps working unchanged alongside it — the
+same guarantee as the non-MIG `nvml` provider.
+
+Note when joining the two in PromQL: DCGM labels MIG series with `UUID`,
+`GPU_I_ID`, and `GPU_I_PROFILE`, while Aitra Meter uses `gpu_uuid` and
+`mig_instance`, and the `mig_instance` index is the enumeration order rather
+than `GPU_I_ID`. Joins need label rewriting and a mapping between the two
+index schemes; there is no automatic correlation today.
+
+## Limitations
+
+- **No sub-slice attribution.** Attribution stops at the MIG compute
+  instance. Processes sharing one slice are not separated.
+- **Proportional, not measured.** Per-slice energy is the parent's measured
+  energy split by compute-slice fraction. It does not reflect per-slice
+  activity differences.
+- **One pinned inference server per node** for token metrics. Multi-tenant
+  pod-to-slice mapping is not implemented.
+- **Profile names are derived**, not read from NVML's profile-info API
+  (see label conventions above).
+- Geometry changes mid-window are attributed against the geometry captured at
+  window start.
+- The cost counter needs an electricity price flag; there is no SiteConfig
+  integration on the agent side yet.
+- AMD ROCm partitioning and time-sliced GPU sharing are out of scope
+  (see issue #43).

--- a/helm/aitra-meter/templates/measurement-agent.yaml
+++ b/helm/aitra-meter/templates/measurement-agent.yaml
@@ -44,6 +44,20 @@ spec:
             - --inference-provider={{ .Values.measurementAgent.inferenceProvider.type }}
             - --aggregator={{ include "aitra-meter.fullname" . }}-aggregation-service:9091
             - --log-level=info
+            {{- with .Values.measurementAgent.mig }}
+            {{- if .pinnedInstance }}
+            - --mig-instance={{ .pinnedInstance }}
+            {{- end }}
+            {{- if .namespace }}
+            - --mig-namespace={{ .namespace }}
+            {{- end }}
+            {{- if .team }}
+            - --mig-team={{ .team }}
+            {{- end }}
+            {{- if .electricityCostUSDPerKWh }}
+            - --electricity-cost-usd-per-kwh={{ .electricityCostUSDPerKWh }}
+            {{- end }}
+            {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -60,6 +60,23 @@ measurementAgent:
   cvThreshold: 0.03
   cvWindowSize: 100
 
+  # MIG attribution (nvml energy provider only, docs/reference/mig-support.md).
+  # MIG mode itself is detected automatically by the agent at startup; these
+  # values only refine the labels on the aitra_mig_* metrics and enable the
+  # per-slice cost counter. All optional.
+  mig:
+    # The MIG slice the node's inference server is pinned to, as a
+    # mig_instance label ("mig-1g.10gb:0") or MIG device UUID ("MIG-…", the
+    # CUDA_VISIBLE_DEVICES value of the inference pod). Leave empty to
+    # auto-pin when the node exposes exactly one slice.
+    pinnedInstance: ""
+    # Namespace label for aitra_mig_* token/cost metrics (default "unknown").
+    namespace: ""
+    # Team label for aitra_mig_cost_usd_total (default "unknown").
+    team: ""
+    # Electricity price in USD/kWh; 0 disables aitra_mig_cost_usd_total.
+    electricityCostUSDPerKWh: 0
+
 aggregationService:
   image:
     repository: ghcr.io/aitra-ai/aitra-meter/aggregation-service

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -52,6 +52,12 @@ type Config struct {
 	// EnergyProvider and InferenceProvider are the measurement backends.
 	EnergyProvider    provider.EnergyProvider
 	InferenceProvider provider.InferenceMetricsProvider
+
+	// MIG configures per-slice attribution labels on MIG nodes. Only
+	// consulted when EnergyProvider implements provider.MIGEnergyProvider
+	// and reports MIG mode; the zero value is valid (labels default to
+	// "unknown", cost counter disabled).
+	MIG MIGAttribution
 }
 
 // Loop runs the measurement loop for a single node.
@@ -150,8 +156,19 @@ func (l *Loop) Run(ctx context.Context) {
 }
 
 // reportWindow ends the current energy window and sends the WindowReport.
+// On MIG nodes the window is ended via EndWindowMIG so the per-slice
+// breakdown feeds the aitra_mig_* metrics alongside the node total.
 func (l *Loop) reportWindow(ctx context.Context, windowID string) {
-	joules, err := l.cfg.EnergyProvider.EndWindow(ctx, windowID)
+	var (
+		joules    float64
+		migSlices []provider.MIGSliceEnergy
+		err       error
+	)
+	if migp, ok := l.cfg.EnergyProvider.(provider.MIGEnergyProvider); ok && migp.MIGEnabled() {
+		joules, migSlices, err = migp.EndWindowMIG(ctx, windowID)
+	} else {
+		joules, err = l.cfg.EnergyProvider.EndWindow(ctx, windowID)
+	}
 	if err != nil {
 		l.log.Warn("EndWindow failed — dropping window",
 			zap.String("window_id", windowID),
@@ -174,6 +191,12 @@ func (l *Loop) reportWindow(ctx context.Context, windowID string) {
 		l.seenFirstToken = true
 	} else {
 		l.log.Warn("OutputTokens read failed", zap.Error(tokErr))
+	}
+
+	// MIG per-slice metrics (issue #43). Power is recorded for every slice;
+	// token-derived metrics only for the pinned slice on serving windows.
+	if len(migSlices) > 0 {
+		observeMIGWindow(l.cfg.Node, modelName, l.cfg.MIG, migSlices, tokenDelta)
 	}
 
 	powerWatts := joules / l.cfg.WindowDuration.Seconds()

--- a/internal/agent/mig.go
+++ b/internal/agent/mig.go
@@ -1,0 +1,104 @@
+// MIG attribution in the measurement loop (issue #43).
+//
+// When the energy provider implements provider.MIGEnergyProvider and reports
+// MIG mode, the loop ends each window with EndWindowMIG and records the
+// aitra_mig_* metrics here. Token attribution follows the v0.9.0 scope: all
+// output tokens from the node's inference server are attributed to the one
+// MIG slice that server is pinned to (via CUDA_VISIBLE_DEVICES on the
+// inference pod, named to the agent with --mig-instance). Multi-tenant
+// pod-to-slice mapping is out of scope; see docs/reference/mig-support.md.
+
+package agent
+
+import (
+	"github.com/aitra-ai/aitra-meter/internal/metrics"
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// joulesPerKWh is the number of joules in one kilowatt-hour.
+const joulesPerKWh = 3_600_000.0
+
+// MIGAttribution configures how per-slice MIG metrics are labelled and
+// whether the cost counter is derived. Only consulted on nodes where the
+// energy provider detects MIG mode.
+type MIGAttribution struct {
+	// PinnedInstance names the slice the node's inference server is pinned
+	// to, either as a mig_instance label ("mig-1g.10gb:0") or a MIG device
+	// UUID ("MIG-…", the CUDA_VISIBLE_DEVICES value of the inference pod).
+	// Empty: tokens are auto-attributed only when the node exposes exactly
+	// one MIG slice; with several slices and no pin, token metrics stay
+	// absent (power is still recorded per slice).
+	PinnedInstance string
+
+	// Namespace of the pinned inference pod. Label value only.
+	// Defaults to "unknown".
+	Namespace string
+
+	// Team label for aitra_mig_cost_usd_total. Defaults to "unknown".
+	Team string
+
+	// ElectricityCostPerKWh is the electricity price in USD/kWh used for
+	// aitra_mig_cost_usd_total. Zero disables the cost counter.
+	ElectricityCostPerKWh float64
+}
+
+// observeMIGWindow records the aitra_mig_* metrics for one measurement window.
+//
+// Per-slice power is recorded for every slice. Token-derived metrics
+// (tokens, J/token, cost) are recorded only for the pinned slice and only
+// for serving windows (tokenDelta > 0).
+func observeMIGWindow(node, model string, att MIGAttribution, slices []provider.MIGSliceEnergy, tokenDelta uint64) {
+	if len(slices) == 0 {
+		return
+	}
+	if att.Namespace == "" {
+		att.Namespace = "unknown"
+	}
+	if att.Team == "" {
+		att.Team = "unknown"
+	}
+	if model == "" {
+		model = "unknown"
+	}
+
+	for _, se := range slices {
+		metrics.MIGPowerWatts.
+			WithLabelValues(node, se.Slice.ParentUUID, se.Slice.Instance).
+			Set(se.PowerWatts)
+	}
+
+	pinned, ok := resolvePinnedSlice(att.PinnedInstance, slices)
+	if !ok || tokenDelta == 0 {
+		return
+	}
+
+	metrics.MIGTokensTotal.
+		WithLabelValues(node, pinned.Slice.ParentUUID, pinned.Slice.Instance, att.Namespace, model).
+		Add(float64(tokenDelta))
+	metrics.MIGJPerToken.
+		WithLabelValues(node, pinned.Slice.ParentUUID, pinned.Slice.Instance, att.Namespace, model).
+		Set(pinned.Joules / float64(tokenDelta))
+	if att.ElectricityCostPerKWh > 0 {
+		metrics.MIGCostUSDTotal.
+			WithLabelValues(node, pinned.Slice.ParentUUID, pinned.Slice.Instance, att.Namespace, att.Team).
+			Add(pinned.Joules / joulesPerKWh * att.ElectricityCostPerKWh)
+	}
+}
+
+// resolvePinnedSlice finds the slice tokens should be attributed to.
+// pin matches either the mig_instance label or the MIG device UUID. An empty
+// pin resolves only when there is exactly one slice on the node.
+func resolvePinnedSlice(pin string, slices []provider.MIGSliceEnergy) (provider.MIGSliceEnergy, bool) {
+	if pin == "" {
+		if len(slices) == 1 {
+			return slices[0], true
+		}
+		return provider.MIGSliceEnergy{}, false
+	}
+	for _, se := range slices {
+		if se.Slice.Instance == pin || (se.Slice.UUID != "" && se.Slice.UUID == pin) {
+			return se, true
+		}
+	}
+	return provider.MIGSliceEnergy{}, false
+}

--- a/internal/agent/mig_test.go
+++ b/internal/agent/mig_test.go
@@ -1,0 +1,225 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/zap"
+
+	"github.com/aitra-ai/aitra-meter/internal/metrics"
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// migSliceEnergy builds a MIGSliceEnergy for tests.
+func migSliceEnergy(parent, instance, uuid string, joules, watts float64) provider.MIGSliceEnergy {
+	return provider.MIGSliceEnergy{
+		Slice: provider.MIGSlice{
+			ParentUUID: parent,
+			Instance:   instance,
+			UUID:       uuid,
+		},
+		Joules:     joules,
+		PowerWatts: watts,
+	}
+}
+
+func TestResolvePinnedSlice(t *testing.T) {
+	a := migSliceEnergy("GPU-A", "mig-1g.10gb:0", "MIG-aaa", 3, 0.3)
+	b := migSliceEnergy("GPU-A", "mig-1g.10gb:1", "MIG-bbb", 4, 0.4)
+
+	tests := []struct {
+		name     string
+		pin      string
+		slices   []provider.MIGSliceEnergy
+		wantOK   bool
+		wantUUID string
+	}{
+		{"empty pin, single slice auto-pins", "", []provider.MIGSliceEnergy{a}, true, "MIG-aaa"},
+		{"empty pin, multiple slices unresolved", "", []provider.MIGSliceEnergy{a, b}, false, ""},
+		{"pin by instance label", "mig-1g.10gb:1", []provider.MIGSliceEnergy{a, b}, true, "MIG-bbb"},
+		{"pin by MIG UUID", "MIG-aaa", []provider.MIGSliceEnergy{a, b}, true, "MIG-aaa"},
+		{"pin with no match", "mig-2g.20gb:0", []provider.MIGSliceEnergy{a, b}, false, ""},
+		{"no slices", "mig-1g.10gb:0", nil, false, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := resolvePinnedSlice(tc.pin, tc.slices)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got.Slice.UUID != tc.wantUUID {
+				t.Errorf("resolved UUID = %q, want %q", got.Slice.UUID, tc.wantUUID)
+			}
+		})
+	}
+}
+
+func TestObserveMIGWindowPinnedSlice(t *testing.T) {
+	// Unique label values so parallel/global metric state cannot collide
+	// with other tests.
+	const (
+		node    = "mig-obs-node-1"
+		parent  = "GPU-obs-1"
+		instA   = "mig-1g.10gb:0"
+		instB   = "mig-1g.10gb:1"
+		nsLabel = "tenant-a"
+		model   = "llama-3-8b"
+		team    = "ml-platform"
+	)
+	slices := []provider.MIGSliceEnergy{
+		migSliceEnergy(parent, instA, "MIG-obs-aaa", 30, 1.0),
+		migSliceEnergy(parent, instB, "MIG-obs-bbb", 45, 1.5),
+	}
+	att := MIGAttribution{
+		PinnedInstance:        instA,
+		Namespace:             nsLabel,
+		Team:                  team,
+		ElectricityCostPerKWh: 0.20,
+	}
+
+	observeMIGWindow(node, model, att, slices, 600)
+
+	// Power is recorded for every slice.
+	if got := testutil.ToFloat64(metrics.MIGPowerWatts.WithLabelValues(node, parent, instA)); got != 1.0 {
+		t.Errorf("MIGPowerWatts[%s] = %v, want 1.0", instA, got)
+	}
+	if got := testutil.ToFloat64(metrics.MIGPowerWatts.WithLabelValues(node, parent, instB)); got != 1.5 {
+		t.Errorf("MIGPowerWatts[%s] = %v, want 1.5", instB, got)
+	}
+
+	// Token-derived metrics only for the pinned slice.
+	if got := testutil.ToFloat64(metrics.MIGTokensTotal.WithLabelValues(node, parent, instA, nsLabel, model)); got != 600 {
+		t.Errorf("MIGTokensTotal = %v, want 600", got)
+	}
+	if got := testutil.ToFloat64(metrics.MIGJPerToken.WithLabelValues(node, parent, instA, nsLabel, model)); got != 30.0/600 {
+		t.Errorf("MIGJPerToken = %v, want %v", got, 30.0/600)
+	}
+	joules, price := 30.0, 0.20
+	wantCost := joules / 3_600_000.0 * price // runtime arithmetic, same rounding as the code under test
+	if got := testutil.ToFloat64(metrics.MIGCostUSDTotal.WithLabelValues(node, parent, instA, nsLabel, team)); got != wantCost {
+		t.Errorf("MIGCostUSDTotal = %v, want %v", got, wantCost)
+	}
+
+	// The unpinned slice must not have token metrics.
+	if got := testutil.ToFloat64(metrics.MIGTokensTotal.WithLabelValues(node, parent, instB, nsLabel, model)); got != 0 {
+		t.Errorf("MIGTokensTotal for unpinned slice = %v, want 0", got)
+	}
+}
+
+func TestObserveMIGWindowIdleWindowRecordsPowerOnly(t *testing.T) {
+	const (
+		node   = "mig-obs-node-2"
+		parent = "GPU-obs-2"
+		inst   = "mig-2g.20gb:0"
+	)
+	slices := []provider.MIGSliceEnergy{migSliceEnergy(parent, inst, "MIG-obs-ccc", 12, 0.4)}
+
+	observeMIGWindow(node, "m", MIGAttribution{}, slices, 0)
+
+	if got := testutil.ToFloat64(metrics.MIGPowerWatts.WithLabelValues(node, parent, inst)); got != 0.4 {
+		t.Errorf("MIGPowerWatts = %v, want 0.4", got)
+	}
+	// tokenDelta == 0 → no tokens, no J/token (labels default to "unknown").
+	if got := testutil.ToFloat64(metrics.MIGTokensTotal.WithLabelValues(node, parent, inst, "unknown", "m")); got != 0 {
+		t.Errorf("MIGTokensTotal = %v, want 0 for idle window", got)
+	}
+}
+
+func TestObserveMIGWindowCostDisabledWithoutPrice(t *testing.T) {
+	const (
+		node   = "mig-obs-node-3"
+		parent = "GPU-obs-3"
+		inst   = "mig-1g.10gb:0"
+	)
+	slices := []provider.MIGSliceEnergy{migSliceEnergy(parent, inst, "MIG-obs-ddd", 10, 0.3)}
+
+	observeMIGWindow(node, "m", MIGAttribution{}, slices, 100)
+
+	if got := testutil.ToFloat64(metrics.MIGCostUSDTotal.WithLabelValues(node, parent, inst, "unknown", "unknown")); got != 0 {
+		t.Errorf("MIGCostUSDTotal = %v, want 0 when ElectricityCostPerKWh is unset", got)
+	}
+	// Tokens and J/token still recorded with defaulted labels.
+	if got := testutil.ToFloat64(metrics.MIGTokensTotal.WithLabelValues(node, parent, inst, "unknown", "m")); got != 100 {
+		t.Errorf("MIGTokensTotal = %v, want 100", got)
+	}
+}
+
+// --- loop integration ---------------------------------------------------------
+
+// fakeMIGEnergy implements provider.MIGEnergyProvider for loop tests.
+type fakeMIGEnergy struct {
+	joules float64
+	slices []provider.MIGSliceEnergy
+}
+
+func (f *fakeMIGEnergy) Name() string                                  { return "fake-mig-energy" }
+func (f *fakeMIGEnergy) BeginWindow(_ context.Context, _ string) error { return nil }
+func (f *fakeMIGEnergy) EndWindow(_ context.Context, _ string) (float64, error) {
+	return f.joules, nil
+}
+func (f *fakeMIGEnergy) IdlePower(_ context.Context) (float64, error)         { return 0, nil }
+func (f *fakeMIGEnergy) Devices(_ context.Context) ([]provider.Device, error) { return nil, nil }
+func (f *fakeMIGEnergy) MIGEnabled() bool                                     { return true }
+func (f *fakeMIGEnergy) MIGSlices(_ context.Context) ([]provider.MIGSlice, error) {
+	out := make([]provider.MIGSlice, len(f.slices))
+	for i, se := range f.slices {
+		out[i] = se.Slice
+	}
+	return out, nil
+}
+func (f *fakeMIGEnergy) EndWindowMIG(_ context.Context, _ string) (float64, []provider.MIGSliceEnergy, error) {
+	return f.joules, f.slices, nil
+}
+
+func TestLoopMIGWindowPopulatesSliceMetrics(t *testing.T) {
+	addr, svc, stop := startFakeAggSvc(t)
+	defer stop()
+
+	const (
+		node   = "mig-loop-node"
+		parent = "GPU-loop-1"
+		inst   = "mig-3g.40gb:0"
+		nsL    = "tenant-loop"
+	)
+	energy := &fakeMIGEnergy{
+		joules: 90,
+		slices: []provider.MIGSliceEnergy{migSliceEnergy(parent, inst, "MIG-loop-aaa", 90, 3.0)},
+	}
+	loop, err := New(Config{
+		Node:              node,
+		AggregatorAddr:    addr,
+		WindowDuration:    20 * time.Millisecond,
+		EnergyProvider:    energy,
+		InferenceProvider: &incrementingInference{step: 250, model: "m-loop"},
+		MIG:               MIGAttribution{Namespace: nsL},
+	}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer loop.Close() //nolint:errcheck
+
+	runFor(loop, 120*time.Millisecond)
+
+	if len(svc.all()) < 2 {
+		t.Fatalf("expected ≥2 WindowReports, got %d", len(svc.all()))
+	}
+
+	// Power gauge set for the slice.
+	if got := testutil.ToFloat64(metrics.MIGPowerWatts.WithLabelValues(node, parent, inst)); got != 3.0 {
+		t.Errorf("MIGPowerWatts = %v, want 3.0", got)
+	}
+	// Single slice + no explicit pin → auto-pinned; token deltas of 250
+	// accrue from the second window onward.
+	tokens := testutil.ToFloat64(metrics.MIGTokensTotal.WithLabelValues(node, parent, inst, nsL, "m-loop"))
+	if tokens == 0 {
+		t.Error("MIGTokensTotal = 0, want > 0 (auto-pinned single slice)")
+	}
+	if int(tokens)%250 != 0 {
+		t.Errorf("MIGTokensTotal = %v, want a multiple of 250", tokens)
+	}
+	if got := testutil.ToFloat64(metrics.MIGJPerToken.WithLabelValues(node, parent, inst, nsL, "m-loop")); got != 90.0/250 {
+		t.Errorf("MIGJPerToken = %v, want %v", got, 90.0/250)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -143,6 +143,37 @@ var (
 		Help: "Cumulative energy cost in USD attributed to a tenant, summed per measurement window.",
 	}, []string{"namespace", "team", "cost_center"})
 
+	// --- MIG attribution (issue #43) -----------------------------------------
+	// Populated by the measurement agent on nodes where MIG mode is detected
+	// (nvml energy provider only). mig_instance follows the DCGM naming
+	// convention (e.g. "mig-1g.10gb:0"); gpu_uuid is the UUID of the parent
+	// physical GPU. See docs/reference/mig-support.md for the attribution model.
+
+	// MIGJPerToken is J/token for a MIG slice with a pinned inference server.
+	MIGJPerToken = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_mig_j_per_token",
+		Help: "Joules per output token for a MIG slice over the last measurement window.",
+	}, []string{"node", "gpu_uuid", "mig_instance", "namespace", "model"})
+
+	// MIGTokensTotal counts output tokens attributed to a MIG slice.
+	MIGTokensTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aitra_mig_tokens_total",
+		Help: "Cumulative output tokens attributed to a MIG slice.",
+	}, []string{"node", "gpu_uuid", "mig_instance", "namespace", "model"})
+
+	// MIGCostUSDTotal accrues per-slice energy cost. Absent until the agent is
+	// started with --electricity-cost-usd-per-kwh > 0.
+	MIGCostUSDTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aitra_mig_cost_usd_total",
+		Help: "Cumulative energy cost in USD attributed to a MIG slice.",
+	}, []string{"node", "gpu_uuid", "mig_instance", "namespace", "team"})
+
+	// MIGPowerWatts is the power share attributed to a MIG slice.
+	MIGPowerWatts = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_mig_power_watts",
+		Help: "Power in watts attributed to a MIG slice: parent GPU window energy split by compute slice fraction, divided by window duration.",
+	}, []string{"node", "gpu_uuid", "mig_instance"})
+
 	// GPUServingUtilizationRatio is the fraction of elapsed time a node was
 	// serving inference requests: (window - idle) / window. Distinct from DCGM SM
 	// utilization. Populated by the idle-tracking follow-up to #40.

--- a/internal/provider/energy/nvml/mig.go
+++ b/internal/provider/energy/nvml/mig.go
@@ -1,0 +1,210 @@
+// MIG (Multi-Instance GPU) attribution accounting for the NVML energy
+// provider (issue #43).
+//
+// This file is intentionally free of build tags and go-nvml imports so the
+// attribution logic can be unit-tested on machines without GPUs or CGO. The
+// NVML-backed migReader implementation and the provider.MIGEnergyProvider
+// methods on NVMLProvider live in mig_nvml.go behind the linux build tag.
+
+package nvml
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// migReader abstracts the NVML queries migTracker needs, so the accounting
+// can be tested against a fake without GPU hardware.
+type migReader interface {
+	// Slices enumerates the MIG compute instances on the node.
+	Slices() ([]provider.MIGSlice, error)
+
+	// ParentEnergyMillijoules returns the cumulative energy counter of the
+	// physical GPU identified by uuid, in millijoules.
+	ParentEnergyMillijoules(uuid string) (float64, error)
+}
+
+// migTracker attributes parent-GPU window energy to MIG slices.
+//
+// NVML does not expose a per-slice energy sensor: A100/H100 boards have
+// board-level power rails only, so nvmlDeviceGetTotalEnergyConsumption is
+// meaningful on the physical GPU handle, not per MIG instance. The tracker
+// therefore measures each parent GPU's energy delta over the window and
+// splits it across that GPU's slices proportionally to their compute slice
+// count (GpuInstanceSliceCount). The split conserves energy: per-slice values
+// on a parent always sum to the parent's measured delta. See
+// docs/reference/mig-support.md for the full attribution model.
+type migTracker struct {
+	reader migReader
+
+	// now is time.Now, injectable for tests.
+	now func() time.Time
+
+	mu      sync.Mutex
+	windows map[string]*migWindow
+}
+
+type migWindow struct {
+	start time.Time
+	// slices is the MIG geometry captured at window start.
+	slices []provider.MIGSlice
+	// parentStartMJ holds the start energy counter per parent GPU UUID.
+	// Parents whose counter could not be read at window start are absent
+	// and are excluded from attribution for this window.
+	parentStartMJ map[string]float64
+}
+
+func newMIGTracker(reader migReader) *migTracker {
+	return &migTracker{
+		reader:  reader,
+		now:     time.Now,
+		windows: make(map[string]*migWindow),
+	}
+}
+
+// beginWindow snapshots the MIG geometry and per-parent energy counters.
+// Geometry is re-read every window because MIG instances can be created or
+// destroyed at runtime.
+func (t *migTracker) beginWindow(windowID string) error {
+	slices, err := t.reader.Slices()
+	if err != nil {
+		return fmt.Errorf("mig: enumerate slices: %w", err)
+	}
+
+	w := &migWindow{
+		start:         t.now(),
+		slices:        slices,
+		parentStartMJ: make(map[string]float64),
+	}
+	for _, s := range slices {
+		if _, ok := w.parentStartMJ[s.ParentUUID]; ok {
+			continue
+		}
+		mj, err := t.reader.ParentEnergyMillijoules(s.ParentUUID)
+		if err != nil {
+			// Best effort: skip this parent for the window rather than
+			// failing the whole measurement.
+			continue
+		}
+		w.parentStartMJ[s.ParentUUID] = mj
+	}
+
+	t.mu.Lock()
+	t.windows[windowID] = w
+	t.mu.Unlock()
+	return nil
+}
+
+// endWindow computes the per-slice energy breakdown for a window started with
+// beginWindow. Parents whose energy counter cannot be read at window end are
+// skipped. The result is ordered by (ParentIndex, Index).
+func (t *migTracker) endWindow(windowID string) ([]provider.MIGSliceEnergy, error) {
+	t.mu.Lock()
+	w, ok := t.windows[windowID]
+	delete(t.windows, windowID)
+	t.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("mig: window %q not found", windowID)
+	}
+
+	elapsed := t.now().Sub(w.start).Seconds()
+
+	// Group slices by parent, preserving discovery order.
+	byParent := make(map[string][]provider.MIGSlice)
+	for _, s := range w.slices {
+		byParent[s.ParentUUID] = append(byParent[s.ParentUUID], s)
+	}
+
+	var out []provider.MIGSliceEnergy
+	for parent, slices := range byParent {
+		startMJ, ok := w.parentStartMJ[parent]
+		if !ok {
+			continue // counter unreadable at window start
+		}
+		endMJ, err := t.reader.ParentEnergyMillijoules(parent)
+		if err != nil {
+			continue // counter unreadable at window end
+		}
+		deltaJ := (endMJ - startMJ) / 1000.0
+		if deltaJ < 0 {
+			deltaJ = 0 // counter reset (driver reload)
+		}
+		out = append(out, attributeParent(slices, deltaJ, elapsed)...)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i].Slice, out[j].Slice
+		if a.ParentIndex != b.ParentIndex {
+			return a.ParentIndex < b.ParentIndex
+		}
+		return a.Index < b.Index
+	})
+	return out, nil
+}
+
+// discardWindow drops window state without computing attribution. Called when
+// the total energy measurement for the window failed.
+func (t *migTracker) discardWindow(windowID string) {
+	t.mu.Lock()
+	delete(t.windows, windowID)
+	t.mu.Unlock()
+}
+
+// attributeParent splits one parent GPU's window energy across its slices in
+// proportion to ComputeSlices. When no slice reports a compute slice count
+// (attribute query failed for all), the energy is split equally so it is
+// never silently dropped.
+func attributeParent(slices []provider.MIGSlice, parentJoules, elapsedSecs float64) []provider.MIGSliceEnergy {
+	if len(slices) == 0 {
+		return nil
+	}
+	totalCompute := 0
+	for _, s := range slices {
+		totalCompute += s.ComputeSlices
+	}
+
+	out := make([]provider.MIGSliceEnergy, 0, len(slices))
+	for _, s := range slices {
+		var share float64
+		if totalCompute > 0 {
+			share = float64(s.ComputeSlices) / float64(totalCompute)
+		} else {
+			share = 1.0 / float64(len(slices))
+		}
+		joules := parentJoules * share
+		var watts float64
+		if elapsedSecs > 0 {
+			watts = joules / elapsedSecs
+		}
+		out = append(out, provider.MIGSliceEnergy{
+			Slice:      s,
+			Joules:     joules,
+			PowerWatts: watts,
+		})
+	}
+	return out
+}
+
+// migProfileName builds the DCGM-style profile name, e.g. "1g.10gb".
+//
+// NVML reports the usable framebuffer, which is slightly below the nominal
+// profile size because the driver reserves memory (e.g. 9728 MiB for a
+// 1g.10gb instance, 40192 MiB for 3g.40gb). Rounding up to the next GiB
+// therefore recovers the nominal size for every A100/H100 profile we are
+// aware of. This derivation has not been verified on MIG hardware yet; if a
+// profile name comes out wrong the label is still stable and unique per
+// slice — see docs/reference/mig-support.md.
+func migProfileName(computeSlices int, memoryMB uint64) string {
+	gb := (memoryMB + 1023) / 1024
+	return fmt.Sprintf("%dg.%dgb", computeSlices, gb)
+}
+
+// migInstanceLabel builds the mig_instance metric label value,
+// e.g. "mig-1g.10gb:0". index is the MIG device index on the parent GPU.
+func migInstanceLabel(profile string, index int) string {
+	return fmt.Sprintf("mig-%s:%d", profile, index)
+}

--- a/internal/provider/energy/nvml/mig_nvml.go
+++ b/internal/provider/energy/nvml/mig_nvml.go
@@ -1,0 +1,151 @@
+//go:build linux
+
+// NVML-backed side of MIG attribution (issue #43). Everything in this file
+// touches go-nvml and is therefore gated to linux, like nvml.go. The
+// portable accounting it feeds lives in mig.go.
+
+package nvml
+
+import (
+	"context"
+	"fmt"
+
+	gonvml "github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// NVMLProvider implements provider.MIGEnergyProvider when MIG mode is
+// detected at init (n.mig != nil).
+var _ provider.MIGEnergyProvider = (*NVMLProvider)(nil)
+
+// detectMIGMode reports whether any GPU on the node has MIG mode enabled.
+// GPUs that do not support MIG return ERROR_NOT_SUPPORTED and are skipped.
+func detectMIGMode() bool {
+	count, ret := gonvml.DeviceGetCount()
+	if ret != gonvml.SUCCESS {
+		return false
+	}
+	for i := 0; i < count; i++ {
+		dev, ret := gonvml.DeviceGetHandleByIndex(i)
+		if ret != gonvml.SUCCESS {
+			continue
+		}
+		current, _, ret := gonvml.DeviceGetMigMode(dev)
+		if ret == gonvml.SUCCESS && current == gonvml.DEVICE_MIG_ENABLE {
+			return true
+		}
+	}
+	return false
+}
+
+// nvmlMIGReader implements migReader over go-nvml.
+type nvmlMIGReader struct{}
+
+// Slices enumerates MIG compute instances across all MIG-enabled GPUs.
+// Unconfigured MIG device indexes (no instance behind them) are skipped, so
+// Index is the dense enumeration order — the same order `nvidia-smi -L`
+// lists MIG devices on the parent.
+func (nvmlMIGReader) Slices() ([]provider.MIGSlice, error) {
+	count, ret := gonvml.DeviceGetCount()
+	if ret != gonvml.SUCCESS {
+		return nil, fmt.Errorf("DeviceGetCount: %s", gonvml.ErrorString(ret))
+	}
+
+	var slices []provider.MIGSlice
+	for i := 0; i < count; i++ {
+		dev, ret := gonvml.DeviceGetHandleByIndex(i)
+		if ret != gonvml.SUCCESS {
+			continue
+		}
+		current, _, ret := gonvml.DeviceGetMigMode(dev)
+		if ret != gonvml.SUCCESS || current != gonvml.DEVICE_MIG_ENABLE {
+			continue // MIG unsupported (pre-Ampere) or disabled on this GPU
+		}
+		parentUUID, ret := gonvml.DeviceGetUUID(dev)
+		if ret != gonvml.SUCCESS {
+			continue
+		}
+		maxMig, ret := gonvml.DeviceGetMaxMigDeviceCount(dev)
+		if ret != gonvml.SUCCESS {
+			continue
+		}
+
+		idx := 0
+		for j := 0; j < maxMig; j++ {
+			mig, ret := gonvml.DeviceGetMigDeviceHandleByIndex(dev, j)
+			if ret != gonvml.SUCCESS {
+				continue // index not backed by a configured instance
+			}
+			s := provider.MIGSlice{
+				ParentUUID:  parentUUID,
+				ParentIndex: i,
+				Index:       idx,
+			}
+			if uuid, ret := gonvml.DeviceGetUUID(mig); ret == gonvml.SUCCESS {
+				s.UUID = uuid
+			}
+			if gi, ret := gonvml.DeviceGetGpuInstanceId(mig); ret == gonvml.SUCCESS {
+				s.GPUInstanceID = gi
+			}
+			if attrs, ret := gonvml.DeviceGetAttributes(mig); ret == gonvml.SUCCESS {
+				s.ComputeSlices = int(attrs.GpuInstanceSliceCount)
+				s.MemoryMB = attrs.MemorySizeMB
+			}
+			s.Profile = migProfileName(s.ComputeSlices, s.MemoryMB)
+			s.Instance = migInstanceLabel(s.Profile, s.Index)
+			slices = append(slices, s)
+			idx++
+		}
+	}
+	return slices, nil
+}
+
+// ParentEnergyMillijoules reads the board-level energy accumulator of the
+// physical GPU identified by uuid.
+func (nvmlMIGReader) ParentEnergyMillijoules(uuid string) (float64, error) {
+	dev, ret := gonvml.DeviceGetHandleByUUID(uuid)
+	if ret != gonvml.SUCCESS {
+		return 0, fmt.Errorf("DeviceGetHandleByUUID(%s): %s", uuid, gonvml.ErrorString(ret))
+	}
+	mj, ret := gonvml.DeviceGetTotalEnergyConsumption(dev)
+	if ret != gonvml.SUCCESS {
+		return 0, fmt.Errorf("DeviceGetTotalEnergyConsumption(%s): %s", uuid, gonvml.ErrorString(ret))
+	}
+	return float64(mj), nil
+}
+
+// --- provider.MIGEnergyProvider ---------------------------------------------
+
+// MIGEnabled reports whether MIG mode was detected at provider init.
+func (n *NVMLProvider) MIGEnabled() bool { return n.mig != nil }
+
+// MIGSlices enumerates the MIG compute instances currently configured.
+// Returns an empty list on nodes without MIG mode.
+func (n *NVMLProvider) MIGSlices(ctx context.Context) ([]provider.MIGSlice, error) {
+	if n.mig == nil {
+		return nil, nil
+	}
+	return n.mig.reader.Slices()
+}
+
+// EndWindowMIG ends the window like EndWindow and additionally returns the
+// per-slice energy breakdown. Per-slice attribution is best effort: if it
+// fails, the total is still returned with an empty slice list.
+func (n *NVMLProvider) EndWindowMIG(ctx context.Context, windowID string) (float64, []provider.MIGSliceEnergy, error) {
+	joules, err := n.EndWindow(ctx, windowID)
+	if err != nil {
+		if n.mig != nil {
+			n.mig.discardWindow(windowID)
+		}
+		return 0, nil, err
+	}
+	if n.mig == nil {
+		return joules, nil, nil
+	}
+	slices, err := n.mig.endWindow(windowID)
+	if err != nil {
+		return joules, nil, nil // total is valid; per-slice breakdown unavailable
+	}
+	return joules, slices, nil
+}

--- a/internal/provider/energy/nvml/mig_test.go
+++ b/internal/provider/energy/nvml/mig_test.go
@@ -1,0 +1,294 @@
+// Unit tests for MIG attribution accounting (issue #43). These run on any
+// platform: the NVML calls are mocked behind the migReader interface, so no
+// GPU, CGO, or linux build tag is needed. Behaviour against real MIG
+// hardware is covered by the (pending) integration test documented in
+// docs/reference/mig-support.md.
+
+package nvml
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// fakeMIGReader is a mock migReader. energyMJ is mutated between
+// beginWindow and endWindow to simulate counter advancement.
+type fakeMIGReader struct {
+	slices    []provider.MIGSlice
+	slicesErr error
+	energyMJ  map[string]float64
+	energyErr map[string]error
+}
+
+func (f *fakeMIGReader) Slices() ([]provider.MIGSlice, error) {
+	return f.slices, f.slicesErr
+}
+
+func (f *fakeMIGReader) ParentEnergyMillijoules(uuid string) (float64, error) {
+	if err := f.energyErr[uuid]; err != nil {
+		return 0, err
+	}
+	v, ok := f.energyMJ[uuid]
+	if !ok {
+		return 0, fmt.Errorf("unknown parent %q", uuid)
+	}
+	return v, nil
+}
+
+// newTestTracker returns a tracker with a controllable clock.
+func newTestTracker(r migReader) (*migTracker, *time.Time) {
+	tr := newMIGTracker(r)
+	now := time.Unix(1_700_000_000, 0)
+	tr.now = func() time.Time { return now }
+	return tr, &now
+}
+
+func slice(parent string, parentIdx, idx, computeSlices int, memMB uint64) provider.MIGSlice {
+	profile := migProfileName(computeSlices, memMB)
+	return provider.MIGSlice{
+		ParentUUID:    parent,
+		ParentIndex:   parentIdx,
+		Index:         idx,
+		UUID:          fmt.Sprintf("MIG-%s-%d", parent, idx),
+		Profile:       profile,
+		Instance:      migInstanceLabel(profile, idx),
+		ComputeSlices: computeSlices,
+		MemoryMB:      memMB,
+	}
+}
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// --- label helpers ------------------------------------------------------------
+
+func TestMIGProfileName(t *testing.T) {
+	tests := []struct {
+		computeSlices int
+		memoryMB      uint64
+		want          string
+	}{
+		{1, 4864, "1g.5gb"},   // A100 40GB, usable 4.75 GiB
+		{1, 9728, "1g.10gb"},  // A100 80GB, usable 9.5 GiB
+		{2, 19968, "2g.20gb"}, // A100 80GB, usable 19.5 GiB
+		{3, 40192, "3g.40gb"}, // A100 80GB, usable 39.25 GiB
+		{1, 12032, "1g.12gb"}, // H100 94GB variant
+		{7, 81152, "7g.80gb"}, // full A100 80GB
+		{4, 40960, "4g.40gb"}, // exact GiB boundary stays put
+		{0, 0, "0g.0gb"},      // attributes unavailable — degenerate but stable
+	}
+	for _, tc := range tests {
+		if got := migProfileName(tc.computeSlices, tc.memoryMB); got != tc.want {
+			t.Errorf("migProfileName(%d, %d) = %q, want %q", tc.computeSlices, tc.memoryMB, got, tc.want)
+		}
+	}
+}
+
+func TestMIGInstanceLabel(t *testing.T) {
+	if got := migInstanceLabel("1g.10gb", 0); got != "mig-1g.10gb:0" {
+		t.Errorf("migInstanceLabel = %q, want mig-1g.10gb:0", got)
+	}
+	if got := migInstanceLabel("2g.20gb", 3); got != "mig-2g.20gb:3" {
+		t.Errorf("migInstanceLabel = %q, want mig-2g.20gb:3", got)
+	}
+}
+
+// --- tracker ------------------------------------------------------------------
+
+func TestMIGTrackerProportionalSplit(t *testing.T) {
+	// One parent, two slices with 3 and 4 compute slices. Parent consumes
+	// 7 J over a 10 s window → 3 J and 4 J; 0.3 W and 0.4 W.
+	reader := &fakeMIGReader{
+		slices: []provider.MIGSlice{
+			slice("GPU-A", 0, 0, 3, 40192),
+			slice("GPU-A", 0, 1, 4, 40192),
+		},
+		energyMJ: map[string]float64{"GPU-A": 1000},
+	}
+	tr, now := newTestTracker(reader)
+
+	if err := tr.beginWindow("w1"); err != nil {
+		t.Fatalf("beginWindow: %v", err)
+	}
+	*now = now.Add(10 * time.Second)
+	reader.energyMJ["GPU-A"] = 8000 // +7000 mJ
+
+	got, err := tr.endWindow("w1")
+	if err != nil {
+		t.Fatalf("endWindow: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d slice energies, want 2", len(got))
+	}
+	if !almostEqual(got[0].Joules, 3.0) || !almostEqual(got[1].Joules, 4.0) {
+		t.Errorf("joules = %.3f, %.3f, want 3, 4", got[0].Joules, got[1].Joules)
+	}
+	if !almostEqual(got[0].PowerWatts, 0.3) || !almostEqual(got[1].PowerWatts, 0.4) {
+		t.Errorf("watts = %.3f, %.3f, want 0.3, 0.4", got[0].PowerWatts, got[1].PowerWatts)
+	}
+	// Conservation: per-slice energies sum to the parent's measured delta.
+	if sum := got[0].Joules + got[1].Joules; !almostEqual(sum, 7.0) {
+		t.Errorf("energy not conserved: sum = %.3f, want 7", sum)
+	}
+}
+
+func TestMIGTrackerTwoParents(t *testing.T) {
+	reader := &fakeMIGReader{
+		slices: []provider.MIGSlice{
+			slice("GPU-A", 0, 0, 7, 81152),
+			slice("GPU-B", 1, 0, 1, 9728),
+			slice("GPU-B", 1, 1, 1, 9728),
+		},
+		energyMJ: map[string]float64{"GPU-A": 0, "GPU-B": 0},
+	}
+	tr, now := newTestTracker(reader)
+
+	if err := tr.beginWindow("w"); err != nil {
+		t.Fatalf("beginWindow: %v", err)
+	}
+	*now = now.Add(30 * time.Second)
+	reader.energyMJ["GPU-A"] = 10_000 // 10 J
+	reader.energyMJ["GPU-B"] = 6_000  // 6 J
+
+	got, err := tr.endWindow("w")
+	if err != nil {
+		t.Fatalf("endWindow: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d slice energies, want 3", len(got))
+	}
+	// Sorted by (ParentIndex, Index): GPU-A gets all 10 J; GPU-B splits 6 J equally.
+	if !almostEqual(got[0].Joules, 10.0) {
+		t.Errorf("GPU-A slice joules = %.3f, want 10", got[0].Joules)
+	}
+	if !almostEqual(got[1].Joules, 3.0) || !almostEqual(got[2].Joules, 3.0) {
+		t.Errorf("GPU-B slice joules = %.3f, %.3f, want 3, 3", got[1].Joules, got[2].Joules)
+	}
+}
+
+func TestMIGTrackerEqualSplitWhenAttributesUnavailable(t *testing.T) {
+	// All ComputeSlices zero (DeviceGetAttributes failed) → equal split so
+	// energy is not dropped.
+	reader := &fakeMIGReader{
+		slices: []provider.MIGSlice{
+			slice("GPU-A", 0, 0, 0, 0),
+			slice("GPU-A", 0, 1, 0, 0),
+		},
+		energyMJ: map[string]float64{"GPU-A": 0},
+	}
+	tr, now := newTestTracker(reader)
+	if err := tr.beginWindow("w"); err != nil {
+		t.Fatalf("beginWindow: %v", err)
+	}
+	*now = now.Add(time.Second)
+	reader.energyMJ["GPU-A"] = 4000
+
+	got, err := tr.endWindow("w")
+	if err != nil {
+		t.Fatalf("endWindow: %v", err)
+	}
+	if len(got) != 2 || !almostEqual(got[0].Joules, 2.0) || !almostEqual(got[1].Joules, 2.0) {
+		t.Fatalf("equal split failed: %+v", got)
+	}
+}
+
+func TestMIGTrackerUnknownWindow(t *testing.T) {
+	tr, _ := newTestTracker(&fakeMIGReader{})
+	if _, err := tr.endWindow("nope"); err == nil {
+		t.Error("endWindow for unknown window should return error, got nil")
+	}
+}
+
+func TestMIGTrackerCounterResetClampsToZero(t *testing.T) {
+	// Energy counter goes backwards (driver reload) → 0 J, not negative.
+	reader := &fakeMIGReader{
+		slices:   []provider.MIGSlice{slice("GPU-A", 0, 0, 1, 9728)},
+		energyMJ: map[string]float64{"GPU-A": 9_000_000},
+	}
+	tr, now := newTestTracker(reader)
+	if err := tr.beginWindow("w"); err != nil {
+		t.Fatalf("beginWindow: %v", err)
+	}
+	*now = now.Add(time.Second)
+	reader.energyMJ["GPU-A"] = 100
+
+	got, err := tr.endWindow("w")
+	if err != nil {
+		t.Fatalf("endWindow: %v", err)
+	}
+	if len(got) != 1 || got[0].Joules != 0 || got[0].PowerWatts != 0 {
+		t.Errorf("counter reset should clamp to zero, got %+v", got)
+	}
+}
+
+func TestMIGTrackerParentReadFailureSkipsParent(t *testing.T) {
+	// GPU-B's counter fails at window start; GPU-A must still be attributed.
+	reader := &fakeMIGReader{
+		slices: []provider.MIGSlice{
+			slice("GPU-A", 0, 0, 1, 9728),
+			slice("GPU-B", 1, 0, 1, 9728),
+		},
+		energyMJ:  map[string]float64{"GPU-A": 0},
+		energyErr: map[string]error{"GPU-B": fmt.Errorf("simulated NVML failure")},
+	}
+	tr, now := newTestTracker(reader)
+	if err := tr.beginWindow("w"); err != nil {
+		t.Fatalf("beginWindow: %v", err)
+	}
+	*now = now.Add(time.Second)
+	reader.energyMJ["GPU-A"] = 5000
+
+	got, err := tr.endWindow("w")
+	if err != nil {
+		t.Fatalf("endWindow: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d slice energies, want 1 (GPU-B skipped)", len(got))
+	}
+	if got[0].Slice.ParentUUID != "GPU-A" || !almostEqual(got[0].Joules, 5.0) {
+		t.Errorf("unexpected attribution: %+v", got[0])
+	}
+}
+
+func TestMIGTrackerSlicesEnumerationErrorFailsBegin(t *testing.T) {
+	reader := &fakeMIGReader{slicesErr: fmt.Errorf("simulated enumeration failure")}
+	tr, _ := newTestTracker(reader)
+	if err := tr.beginWindow("w"); err == nil {
+		t.Error("beginWindow should fail when slice enumeration fails")
+	}
+}
+
+func TestMIGTrackerNoSlices(t *testing.T) {
+	// MIG mode on but no compute instances configured: no error, no output.
+	reader := &fakeMIGReader{energyMJ: map[string]float64{}}
+	tr, now := newTestTracker(reader)
+	if err := tr.beginWindow("w"); err != nil {
+		t.Fatalf("beginWindow: %v", err)
+	}
+	*now = now.Add(time.Second)
+	got, err := tr.endWindow("w")
+	if err != nil {
+		t.Fatalf("endWindow: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d slice energies, want 0", len(got))
+	}
+}
+
+func TestMIGTrackerDiscardWindow(t *testing.T) {
+	reader := &fakeMIGReader{
+		slices:   []provider.MIGSlice{slice("GPU-A", 0, 0, 1, 9728)},
+		energyMJ: map[string]float64{"GPU-A": 0},
+	}
+	tr, _ := newTestTracker(reader)
+	if err := tr.beginWindow("w"); err != nil {
+		t.Fatalf("beginWindow: %v", err)
+	}
+	tr.discardWindow("w")
+	if _, err := tr.endWindow("w"); err == nil {
+		t.Error("endWindow after discardWindow should return error")
+	}
+}

--- a/internal/provider/energy/nvml/nvml.go
+++ b/internal/provider/energy/nvml/nvml.go
@@ -29,9 +29,16 @@ func init() {
 
 // NVMLProvider implements provider.EnergyProvider using direct NVML bindings.
 // No Python dependency. NVIDIA GPUs only.
+//
+// When MIG mode is detected at init, the provider also implements
+// provider.MIGEnergyProvider (see mig_nvml.go) and tracks per-slice energy
+// alongside the node total.
 type NVMLProvider struct {
 	mu      sync.Mutex
 	windows map[string]*window
+
+	// mig is non-nil when at least one GPU has MIG mode enabled.
+	mig *migTracker
 }
 
 type window struct {
@@ -45,6 +52,9 @@ func (n *NVMLProvider) init() error {
 		return fmt.Errorf("nvml.Init: %s", gonvml.ErrorString(ret))
 	}
 	n.windows = make(map[string]*window)
+	if detectMIGMode() {
+		n.mig = newMIGTracker(nvmlMIGReader{})
+	}
 	return nil
 }
 
@@ -58,6 +68,11 @@ func (n *NVMLProvider) BeginWindow(ctx context.Context, windowID string) error {
 	n.mu.Lock()
 	n.windows[windowID] = &window{startTime: time.Now(), startEnergy: energy}
 	n.mu.Unlock()
+	if n.mig != nil {
+		// Best effort: a failed MIG snapshot must not fail the node-total
+		// measurement. EndWindowMIG returns an empty slice list in that case.
+		_ = n.mig.beginWindow(windowID)
+	}
 	return nil
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -29,6 +29,72 @@ type EnergyProvider interface {
 	Name() string
 }
 
+// MIGSlice identifies one MIG (Multi-Instance GPU) compute instance on an
+// NVIDIA GPU with MIG mode enabled.
+type MIGSlice struct {
+	// ParentUUID is the UUID of the physical GPU the slice belongs to
+	// (e.g. "GPU-5c8e1a2f-…"). Used as the gpu_uuid metric label.
+	ParentUUID string
+
+	// ParentIndex is the NVML index of the physical GPU.
+	ParentIndex int
+
+	// Index is the MIG device index within the parent GPU, in NVML
+	// enumeration order (the order `nvidia-smi -L` lists MIG devices).
+	Index int
+
+	// UUID is the MIG device UUID (e.g. "MIG-8bf7c667-…"). This is the value
+	// a pinned workload sets in CUDA_VISIBLE_DEVICES.
+	UUID string
+
+	// GPUInstanceID is the NVML GPU instance ID. Matches DCGM's GPU_I_ID label.
+	GPUInstanceID int
+
+	// Profile is the MIG profile name, e.g. "1g.10gb".
+	Profile string
+
+	// Instance is the Prometheus mig_instance label value for this slice,
+	// e.g. "mig-1g.10gb:0". The suffix is Index.
+	Instance string
+
+	// ComputeSlices is the number of GPU compute slices the instance owns
+	// (NVML GpuInstanceSliceCount). Drives proportional energy attribution.
+	ComputeSlices int
+
+	// MemoryMB is the framebuffer memory of the instance in MiB.
+	MemoryMB uint64
+}
+
+// MIGSliceEnergy is the energy attributed to one MIG slice over one
+// measurement window.
+type MIGSliceEnergy struct {
+	Slice      MIGSlice
+	Joules     float64
+	PowerWatts float64
+}
+
+// MIGEnergyProvider is an optional interface an EnergyProvider can implement
+// when it can attribute node energy to individual MIG slices. The agent
+// detects it with a type assertion at startup and switches to MIG-aware
+// windows automatically when MIGEnabled reports true.
+type MIGEnergyProvider interface {
+	EnergyProvider
+
+	// MIGEnabled reports whether at least one GPU on the node has MIG mode
+	// enabled. Evaluated once at provider init.
+	MIGEnabled() bool
+
+	// MIGSlices enumerates the MIG compute instances currently configured
+	// on the node.
+	MIGSlices(ctx context.Context) ([]MIGSlice, error)
+
+	// EndWindowMIG behaves like EndWindow but additionally returns the
+	// per-slice energy breakdown for the window. The error refers to the
+	// total measurement only: when per-slice attribution fails, the total is
+	// still returned with an empty or partial slice list.
+	EndWindowMIG(ctx context.Context, windowID string) (float64, []MIGSliceEnergy, error)
+}
+
 // InferenceMetricsProvider is the interface that inference server adapters must implement.
 // The default implementation reads vLLM's Prometheus /metrics endpoint.
 // Any inference server exposing token counts and request state can implement this.


### PR DESCRIPTION
Closes #43.

- MIG detection and per-slice attribution in the NVML agent path, kept behind the existing CGO/GPU build gating — non-GPU builds compile clean (verified on darwin)
- aitra_mig_* metric family per the issue; unit tests against a mocked NVML interface
- docs/reference/mig-support.md + Helm values (measurementAgent.mig.pinnedInstance/.namespace/.team, electricityCostUSDPerKWh) documented in docs/reference/configuration.md (review fix)

Honesty note: the hardware acceptance criterion (real A100/H100 in MIG mode) cannot be run here — stated plainly in the docs; validation on Open Lab hardware remains open under #36.

Heads-up: this branch and #69 (inference providers) both touch internal/provider/provider.go — merge sequentially and rebase the later one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)