### PR TITLE
chore(codeowners): make @skdwriting the default reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Default owners for everything
-*  @stevenphtan
+*  @skdwriting
 
 # Helm chart
-/helm/  @stevenphtan
+/helm/  @skdwriting
 
 # Go core
-/internal/  @stevenphtan
-/cmd/       @stevenphtan
+/internal/  @skdwriting
+/cmd/       @skdwriting
 
 # Docs
-/docs/  @stevenphtan
+/docs/  @skdwriting


### PR DESCRIPTION
Reassigns code ownership for all paths from `@stevenphtan` to `@skdwriting` (Sanil) so review is **auto-requested on all future PRs**.

This complements the manual reviewer reassignment just applied to the currently-open PRs (#63–#71). Note: CODEOWNERS auto-requests the owner on new PRs, but GitHub never requests a review from a PR's own author, so PRs opened by `@skdwriting` won't self-request.

If you also want CODEOWNERS review to be *required* before merge, enable "Require review from Code Owners" in the branch protection rule for `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwEoubps4f9eAPU45sF4bP)_