### PR TITLE
fix(release): add missing Dockerfiles, unpin image tags, bump chart to 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ secrets/
 Thumbs.db
 
 # Build
-build/
+# Go build output. Note: this must NOT swallow build/*/Dockerfile — the
+# release workflow builds the agent and aggregation images from that
+# path, and a bare "build/" rule silently kept those Dockerfiles out of
+# the repo, breaking every tagged release.
+/build/bin/
+/build/out/
 __pycache__/
 *.pyc

--- a/build/aggregation-service/Dockerfile
+++ b/build/aggregation-service/Dockerfile
@@ -1,0 +1,23 @@
+# Aggregation service — cluster-scoped Deployment. Joins GPU energy with
+# inference token counts and exposes the resulting J/token series to
+# Prometheus.
+FROM golang:1.25-bookworm AS builder
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build \
+      -trimpath \
+      -ldflags "-s -w -X main.version=${VERSION}" \
+      -o /out/aggregation-service \
+      ./cmd/aggregation-service
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /out/aggregation-service /usr/local/bin/aggregation-service
+USER nonroot:nonroot
+EXPOSE 9090
+ENTRYPOINT ["/usr/local/bin/aggregation-service"]

--- a/build/measurement-agent/Dockerfile
+++ b/build/measurement-agent/Dockerfile
@@ -1,0 +1,29 @@
+# Measurement agent — runs as a DaemonSet on GPU nodes.
+#
+# Built CGO_ENABLED=0. The default NVML provider is pure Go (go-nvml dlopens
+# libnvidia-ml.so.1 at runtime from the node's driver installation), so no cgo
+# toolchain is needed here. The AMD provider is gated behind the `amd` build
+# tag and compiles to a stub in this image; ROCm nodes need an image built
+# with `--build-arg BUILD_TAGS=amd` and CGO_ENABLED=1 against the AMD SMI
+# headers.
+FROM golang:1.25-bookworm AS builder
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+ARG BUILD_TAGS=""
+RUN CGO_ENABLED=0 GOOS=linux go build \
+      -tags "${BUILD_TAGS}" \
+      -trimpath \
+      -ldflags "-s -w -X main.version=${VERSION}" \
+      -o /out/measurement-agent \
+      ./cmd/measurement-agent
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /out/measurement-agent /usr/local/bin/measurement-agent
+USER nonroot:nonroot
+ENTRYPOINT ["/usr/local/bin/measurement-agent"]

--- a/helm/aitra-meter/Chart.yaml
+++ b/helm/aitra-meter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aitra-meter
 description: Open-source Kubernetes-native AI inference efficiency measurement
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.8.0
+appVersion: "0.8.0"
 
 keywords:
   - ai
@@ -21,3 +21,5 @@ sources:
 maintainers:
   - name: stevenphtan
     url: https://github.com/stevenphtan
+  - name: skdwriting
+    url: https://github.com/skdwriting

--- a/helm/aitra-meter/templates/aggregation-service.yaml
+++ b/helm/aitra-meter/templates/aggregation-service.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: {{ include "aitra-meter.serviceAccountName" . }}
       containers:
         - name: aggregation-service
-          image: "{{ .Values.aggregationService.image.repository }}:{{ .Values.aggregationService.image.tag }}"
+          image: "{{ .Values.aggregationService.image.repository }}:{{ .Values.aggregationService.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.aggregationService.image.pullPolicy }}
           args:
             - --cluster={{ required "cluster.name is required" .Values.cluster.name }}

--- a/helm/aitra-meter/templates/dashboard.yaml
+++ b/helm/aitra-meter/templates/dashboard.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: dashboard
-          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
+          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
           env:
             - name: PROMETHEUS_URL

--- a/helm/aitra-meter/templates/measurement-agent.yaml
+++ b/helm/aitra-meter/templates/measurement-agent.yaml
@@ -37,7 +37,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: measurement-agent
-          image: "{{ .Values.measurementAgent.image.repository }}:{{ .Values.measurementAgent.image.tag }}"
+          image: "{{ .Values.measurementAgent.image.repository }}:{{ .Values.measurementAgent.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.measurementAgent.image.pullPolicy }}
           args:
             - --energy-provider={{ .Values.measurementAgent.energyProvider.type }}

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -8,7 +8,8 @@ cluster:
 measurementAgent:
   image:
     repository: ghcr.io/aitra-ai/aitra-meter/measurement-agent
-    tag: "0.1.0"
+    # Defaults to the chart appVersion. Override only to pin a specific image.
+    tag: ""
     pullPolicy: IfNotPresent
   # Node selector — DaemonSet only schedules to nodes with this label
   nodeSelector:
@@ -63,7 +64,8 @@ measurementAgent:
 aggregationService:
   image:
     repository: ghcr.io/aitra-ai/aitra-meter/aggregation-service
-    tag: "0.1.0"
+    # Defaults to the chart appVersion. Override only to pin a specific image.
+    tag: ""
     pullPolicy: IfNotPresent
   replicas: 1
   resources:
@@ -79,7 +81,8 @@ dashboard:
   enabled: true
   image:
     repository: ghcr.io/aitra-ai/aitra-meter/dashboard
-    tag: "0.1.0"
+    # Defaults to the chart appVersion. Override only to pin a specific image.
+    tag: ""
     pullPolicy: IfNotPresent
   replicas: 1
   port: 3000


### PR DESCRIPTION
Closes the two release blockers identified in the KubeCon readiness review, plus their root cause.

## The bug
`release.yml` builds `measurement-agent` and `aggregation-service` from `build/*/Dockerfile`. **Neither path exists on `main`.** Any tag push fails the release job before publishing a single image. The v0.8.0 tag would not have shipped.

## Root cause
`.gitignore` line 37 carried a bare `build/` rule intended for Go build output. It also matched the Docker build context, so these Dockerfiles were silently never committed — `git add build/` reported nothing and nobody noticed. Narrowed to `/build/bin/` and `/build/out/`.

## Also fixed
`Chart.yaml` was pinned at `0.1.0` against tags at `v0.2.4`, and `values.yaml` hardcoded all three image tags to `0.1.0`. A fresh `helm install` pulled images two minor versions stale.

Rather than reset the pins to 0.8.0 and let them drift again, image tags now default to `.Chart.AppVersion` and the values are empty. `helm package --app-version` already sets AppVersion at release time, so **images track the release tag with no manual step.** This failure mode is now closed permanently.

## Build details
Default build is `CGO_ENABLED=0` against distroless. The NVML provider is pure Go — `go-nvml` dlopens `libnvidia-ml.so.1` from the node's driver at runtime — and the AMD provider is gated behind the `amd` build tag, compiling to a stub unless requested. ROCm images build with `--build-arg BUILD_TAGS=amd` and `CGO_ENABLED=1`.

## Verification
```
$ helm lint helm/aitra-meter --set cluster.name=ci-lint
1 chart(s) linted, 0 chart(s) failed

$ helm template ... | grep image:
  image: "ghcr.io/aitra-ai/aitra-meter/measurement-agent:0.8.0"
  image: "ghcr.io/aitra-ai/aitra-meter/aggregation-service:0.8.0"
  image: "ghcr.io/aitra-ai/aitra-meter/dashboard:0.8.0"
```

**Merge first.** Nothing else in the queue matters if the tag can't build.
