### PR TITLE
chore(helm): make Grafana the default surface, standalone dashboard opt-in

### DIFF
--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -77,8 +77,14 @@ aggregationService:
       memory: 512Mi
   port: 8080
 
+# Standalone dashboard — a self-contained Next.js UI served from its own image.
+#
+# Off by default. Aitra Meter writes plain Prometheus metrics, and most clusters
+# already run Grafana; the provisioned Grafana dashboards below are the primary
+# surface and require no extra image, no extra Deployment, and no second place to
+# look. Enable this only if you want a standalone view independent of Grafana.
 dashboard:
-  enabled: true
+  enabled: false
   image:
     repository: ghcr.io/aitra-ai/aitra-meter/dashboard
     # Defaults to the chart appVersion. Override only to pin a specific image.
@@ -98,13 +104,18 @@ prometheus:
     interval: 15s
     scrapeTimeout: 10s
 
-# Grafana dashboard provisioning.
-# When enabled, all dashboard JSON files in files/ (overview, cost attribution,
-# AI efficiency, hardware efficiency) are rendered into a ConfigMap labelled for
-# the Grafana dashboard sidecar (kube-prometheus-stack ships it by default), so
-# the dashboards appear in Grafana without a manual import step.
+# Grafana dashboard provisioning — the default surface for Aitra Meter's metrics.
+#
+# All dashboard JSON files in files/ (overview, cost attribution, AI efficiency,
+# hardware efficiency) are rendered into a ConfigMap labelled for the Grafana
+# dashboard sidecar (kube-prometheus-stack ships it by default), so the
+# dashboards appear in Grafana without a manual import step.
+#
+# This requires a Grafana with the dashboard sidecar running in the cluster. If
+# you do not run Grafana, set this to false and enable the standalone dashboard
+# above instead.
 grafana:
-  enabled: false
+  enabled: true
   # Label key/value the Grafana sidecar watches for on dashboard ConfigMaps.
   # kube-prometheus-stack default: grafana_dashboard=1.
   sidecarLabel: grafana_dashboard


### PR DESCRIPTION
Values-only change. Neither template was modified — both are already cleanly gated on their own `enabled` flag.

| | before | after |
|---|---|---|
| `grafana.enabled` | `false` | **`true`** |
| `dashboard.enabled` | `true` | **`false`** |

## Why

Aitra Meter emits plain Prometheus metrics and ships four provisioned Grafana dashboards — overview, cost attribution, AI efficiency, hardware efficiency. Those were **disabled by default**, while a second, self-hosted Next.js UI was **enabled by default**.

That inverts where users actually look. Anyone running Prometheus is almost certainly running Grafana, and the provisioned dashboards need no extra image, no extra Deployment, no Service, and no second place to check. `helm install` should light up the surface the platform team already has open.

The standalone dashboard also carries real cost that a default should not impose: a second container image to build, sign, scan, and patch, in a toolchain (Next.js/Node) otherwise unrelated to this project. Keeping it opt-in means people who want it still get it, and people who don't are not maintaining it by accident.

## Not removed

Both surfaces remain fully supported. `dashboard.enabled: true` restores the previous behavior exactly. The standalone UI stays the right choice for anyone not running Grafana, and remains our demo surface.

## Requires

`grafana.enabled: true` assumes a Grafana with the dashboard sidecar in the cluster (kube-prometheus-stack ships one by default). The values comment now says so, and says to flip to the standalone dashboard if you do not run Grafana.

## Verification

YAML parses; all keys under both blocks intact. I could not run `helm template` in my environment (no Helm binary, install script host not allowlisted) — **worth a `helm template` in CI or locally to confirm the ConfigMap renders and the dashboard Deployment does not.** Both templates are simple `{{- if .Values.X.enabled }}` wrappers so the flip is mechanical, but I would rather it be confirmed than assumed.

@skdwriting