### PR TITLE
feat(host-energy): measure non-accelerator energy + experimental GB10 provider (#82)

### DIFF
--- a/api/proto/measurement/v1/measurement.pb.go
+++ b/api/proto/measurement/v1/measurement.pb.go
@@ -47,8 +47,18 @@ type WindowReport struct {
 	InferenceProvider string `protobuf:"bytes,10,opt,name=inference_provider,json=inferenceProvider,proto3" json:"inference_provider,omitempty"`
 	// Unix timestamp in milliseconds at the end of the window.
 	TimestampUnixMs int64 `protobuf:"varint,11,opt,name=timestamp_unix_ms,json=timestampUnixMs,proto3" json:"timestamp_unix_ms,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Host energy consumed during this window in joules — everything on the node
+	// that is not the accelerator (CPU package, DRAM, and depending on the
+	// provider the wider board). Unset when the node exposes no host telemetry; an
+	// unset field means "not measured", which is deliberately not the same as zero.
+	HostEnergyJoules *float64 `protobuf:"fixed64,12,opt,name=host_energy_joules,json=hostEnergyJoules,proto3,oneof" json:"host_energy_joules,omitempty"`
+	// Host power draw snapshot at window end, in watts. Unset when unavailable.
+	HostPowerWatts *float64 `protobuf:"fixed64,13,opt,name=host_power_watts,json=hostPowerWatts,proto3,oneof" json:"host_power_watts,omitempty"`
+	// Host energy provider identifier (e.g. "rapl", "grace-hwmon"). Empty when host
+	// energy is unavailable. Used for the provider / host_provider metric labels.
+	HostProvider  string `protobuf:"bytes,14,opt,name=host_provider,json=hostProvider,proto3" json:"host_provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WindowReport) Reset() {
@@ -158,6 +168,27 @@ func (x *WindowReport) GetTimestampUnixMs() int64 {
 	return 0
 }
 
+func (x *WindowReport) GetHostEnergyJoules() float64 {
+	if x != nil && x.HostEnergyJoules != nil {
+		return *x.HostEnergyJoules
+	}
+	return 0
+}
+
+func (x *WindowReport) GetHostPowerWatts() float64 {
+	if x != nil && x.HostPowerWatts != nil {
+		return *x.HostPowerWatts
+	}
+	return 0
+}
+
+func (x *WindowReport) GetHostProvider() string {
+	if x != nil {
+		return x.HostProvider
+	}
+	return ""
+}
+
 // WindowAck is returned by the aggregation service after processing a report.
 type WindowAck struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -209,7 +240,7 @@ var File_measurement_v1_measurement_proto protoreflect.FileDescriptor
 
 const file_measurement_v1_measurement_proto_rawDesc = "" +
 	"\n" +
-	" measurement/v1/measurement.proto\x12\x0emeasurement.v1\"\xf5\x02\n" +
+	" measurement/v1/measurement.proto\x12\x0emeasurement.v1\"\xa8\x04\n" +
 	"\fWindowReport\x12\x1b\n" +
 	"\twindow_id\x18\x01 \x01(\tR\bwindowId\x12\x12\n" +
 	"\x04node\x18\x02 \x01(\tR\x04node\x12\x1d\n" +
@@ -224,7 +255,12 @@ const file_measurement_v1_measurement_proto_rawDesc = "" +
 	"\x0fenergy_provider\x18\t \x01(\tR\x0eenergyProvider\x12-\n" +
 	"\x12inference_provider\x18\n" +
 	" \x01(\tR\x11inferenceProvider\x12*\n" +
-	"\x11timestamp_unix_ms\x18\v \x01(\x03R\x0ftimestampUnixMs\"'\n" +
+	"\x11timestamp_unix_ms\x18\v \x01(\x03R\x0ftimestampUnixMs\x121\n" +
+	"\x12host_energy_joules\x18\f \x01(\x01H\x00R\x10hostEnergyJoules\x88\x01\x01\x12-\n" +
+	"\x10host_power_watts\x18\r \x01(\x01H\x01R\x0ehostPowerWatts\x88\x01\x01\x12#\n" +
+	"\rhost_provider\x18\x0e \x01(\tR\fhostProviderB\x15\n" +
+	"\x13_host_energy_joulesB\x13\n" +
+	"\x11_host_power_watts\"'\n" +
 	"\tWindowAck\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted2]\n" +
 	"\x12MeasurementService\x12G\n" +
@@ -262,6 +298,7 @@ func file_measurement_v1_measurement_proto_init() {
 	if File_measurement_v1_measurement_proto != nil {
 		return
 	}
+	file_measurement_v1_measurement_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/api/proto/measurement/v1/measurement.proto
+++ b/api/proto/measurement/v1/measurement.proto
@@ -45,6 +45,19 @@ message WindowReport {
 
   // Unix timestamp in milliseconds at the end of the window.
   int64 timestamp_unix_ms = 11;
+
+  // Host energy consumed during this window in joules — everything on the node
+  // that is not the accelerator (CPU package, DRAM, and depending on the
+  // provider the wider board). Unset when the node exposes no host telemetry; an
+  // unset field means "not measured", which is deliberately not the same as zero.
+  optional double host_energy_joules = 12;
+
+  // Host power draw snapshot at window end, in watts. Unset when unavailable.
+  optional double host_power_watts = 13;
+
+  // Host energy provider identifier (e.g. "rapl", "grace-hwmon"). Empty when host
+  // energy is unavailable. Used for the provider / host_provider metric labels.
+  string host_provider = 14;
 }
 
 // WindowAck is returned by the aggregation service after processing a report.

--- a/cmd/measurement-agent/main.go
+++ b/cmd/measurement-agent/main.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/dcgm"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/zeus"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/hostenergy/gracehwmon"
+	_ "github.com/aitra-ai/aitra-meter/internal/provider/hostenergy/gracespark"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/hostenergy/rapl"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/genericprometheus"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/vllm"
@@ -25,7 +26,7 @@ import (
 
 func main() {
 	energyType := flag.String("energy-provider", "nvml", "Energy provider: nvml | amd | zeus | dcgm")
-	hostEnergyType := flag.String("host-energy-provider", "none", "Host (non-accelerator) energy provider: none | rapl | grace-hwmon")
+	hostEnergyType := flag.String("host-energy-provider", "none", "Host (non-accelerator) energy provider: none | rapl | grace-hwmon | grace-spark-hwmon (experimental)")
 	inferenceType := flag.String("inference-provider", "vllm", "Inference provider: vllm | generic-prometheus")
 	aggregatorAddr := flag.String("aggregator", "aitra-meter-aggregation:9091", "Aggregation service gRPC address")
 	nodeName := flag.String("node", "", "Kubernetes node name (defaults to NODE_NAME env var)")

--- a/cmd/measurement-agent/main.go
+++ b/cmd/measurement-agent/main.go
@@ -17,12 +17,15 @@ import (
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/amd"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/dcgm"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/zeus"
+	_ "github.com/aitra-ai/aitra-meter/internal/provider/hostenergy/gracehwmon"
+	_ "github.com/aitra-ai/aitra-meter/internal/provider/hostenergy/rapl"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/genericprometheus"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/vllm"
 )
 
 func main() {
 	energyType := flag.String("energy-provider", "nvml", "Energy provider: nvml | amd | zeus | dcgm")
+	hostEnergyType := flag.String("host-energy-provider", "none", "Host (non-accelerator) energy provider: none | rapl | grace-hwmon")
 	inferenceType := flag.String("inference-provider", "vllm", "Inference provider: vllm | generic-prometheus")
 	aggregatorAddr := flag.String("aggregator", "aitra-meter-aggregation:9091", "Aggregation service gRPC address")
 	nodeName := flag.String("node", "", "Kubernetes node name (defaults to NODE_NAME env var)")
@@ -45,6 +48,7 @@ func main() {
 	log.Info("starting measurement agent",
 		zap.String("node", node),
 		zap.String("energy_provider", *energyType),
+		zap.String("host_energy_provider", *hostEnergyType),
 		zap.String("inference_provider", *inferenceType),
 		zap.String("aggregator", *aggregatorAddr),
 		zap.Int("window_seconds", *windowSecs),
@@ -56,6 +60,19 @@ func main() {
 			zap.String("provider", *energyType),
 			zap.Error(err),
 		)
+	}
+
+	// Host energy is optional and best-effort: a failure to construct the host
+	// provider must never take down the agent, and must never silently become a
+	// zero reading. On any error we fall back to the Noop provider, which reports
+	// unavailable so host metrics are omitted rather than zeroed.
+	hostEnergyProvider, err := provider.NewHostEnergy(*hostEnergyType, nil)
+	if err != nil {
+		log.Warn("host energy provider init failed — host energy will be reported as unavailable",
+			zap.String("provider", *hostEnergyType),
+			zap.Error(err),
+		)
+		hostEnergyProvider = provider.NewNoopHostEnergy("init failed: " + err.Error())
 	}
 
 	inferenceConfig := map[string]string{}
@@ -71,11 +88,12 @@ func main() {
 	}
 
 	loop, err := agent.New(agent.Config{
-		Node:              node,
-		AggregatorAddr:    *aggregatorAddr,
-		WindowDuration:    time.Duration(*windowSecs) * time.Second,
-		EnergyProvider:    energyProvider,
-		InferenceProvider: inferenceProvider,
+		Node:               node,
+		AggregatorAddr:     *aggregatorAddr,
+		WindowDuration:     time.Duration(*windowSecs) * time.Second,
+		EnergyProvider:     energyProvider,
+		InferenceProvider:  inferenceProvider,
+		HostEnergyProvider: hostEnergyProvider,
 	}, log)
 	if err != nil {
 		log.Fatal("agent init failed", zap.Error(err))

--- a/docs/guides/host-energy.md
+++ b/docs/guides/host-energy.md
@@ -43,7 +43,8 @@ than a component, so it survives non-x86 hardware and board-level paths
 |---|---|---|---|
 | x86 (Intel, AMD) | `rapl` | `/sys/class/powercap/intel-rapl:*/energy_uj` | Supported |
 | Grace Superchip (72-core) | `grace-hwmon` | hwmon `power1_average` / `power1_oem_info` | Supported |
-| GB10 / DGX Spark | — | none | **Unavailable, by design** |
+| GB10 / DGX Spark | `grace-spark-hwmon` | hwmon `energyN_input` via community `antheas/spark_hwmon` | **Experimental — community driver, opt-in** |
+| GB10 / DGX Spark, driver absent | — | none | Unavailable (not zero) |
 | Server-class, any arch | `redfish` | BMC | Future |
 | Default | `none` | Noop (metrics omitted) | Supported |
 
@@ -51,7 +52,7 @@ Configure via Helm:
 
 ```yaml
 hostEnergyProvider:
-  type: rapl   # rapl | grace-hwmon | none
+  type: rapl   # rapl | grace-hwmon | grace-spark-hwmon | none
   config: {}
 ```
 
@@ -100,22 +101,83 @@ the ACPI power meter, hwmon power attributes (`power1_input`, `power1_average`,
 Redfish/IPMI is not an option either).
 
 A community out-of-tree kernel driver (`antheas/spark_hwmon`) reaches the
-MediaTek SSPM firmware's shared memory and does expose cumulative energy counters
-in millijoules through standard hwmon. **Aitra Meter does not take a dependency on
-it.** It is unsigned and out-of-tree, needs DKMS and MOK keys under Secure Boot,
-is self-described by its author as "vibe coded", and its firmware ABI is
-explicitly still in flux. Building a shipped provider on an unstable ABI, or
-asking users to install such a driver, is not a reasonable ask.
+MediaTek SSPM firmware's shared memory and exposes cumulative energy counters in
+millijoules through standard hwmon. **Aitra Meter takes no dependency on it and
+does not ship, install, sign, or version-check it.** It is unsigned and
+out-of-tree, needs DKMS and MOK keys under Secure Boot, is self-described by its
+author as "vibe coded", and its firmware ABI is explicitly still in flux.
 
-On GB10, host energy is `unavailable`, and Aitra Meter says so. That is the
-honest state — and it is a stronger position than silently reporting a wrong
-number.
+So on a **stock** GB10 — no community driver — host energy is `unavailable`, and
+Aitra Meter says so. That is the honest state, and a stronger position than
+silently reporting a wrong number.
 
-> **Sizing the error, separately.** For a one-off *benchmark* (not a shipped
-> path), `antheas/spark_hwmon` can be installed on a GB10 to quantify how large
-> the host share actually is. A measured example on a GB10 (one small–mid model,
-> concurrency 8, eager mode): the GPU drew ≈30 % of total box power, i.e. GPU-only
-> J/token undercounted whole-system energy by ≈3.3×, and — measured across the
-> qwen2.5 0.5B→32B ladder — that ratio was roughly **constant** rather than
-> shrinking with model size. Treat these as hardware- and load-specific: on a
-> datacenter GPU drawing 400–700 W the host share is far smaller.
+For operators who have *chosen* to install that driver, the experimental
+`grace-spark-hwmon` provider (below) will read it. It remains opt-in, and it never
+relaxes the "absent is not zero" rule: a driver that is absent, or a reading that
+is malformed or goes backwards, is reported as unavailable, never as zero.
+
+## `grace-spark-hwmon` (GB10 / DGX Spark) — experimental, opt-in
+
+**Status: experimental, community-dependency, off by default.** Distinct from
+`grace-hwmon` (the 72-core Superchip) because the sysfs surface and the caveats
+differ. Enable only on a GB10 where you have installed the `antheas/spark_hwmon`
+driver yourself.
+
+The driver reads the Spark's System Power Budget Manager (SPBM) shared memory —
+updated by the MediaTek SSPM firmware — and presents it through ordinary hwmon
+sysfs. Aitra reads it exactly as it would read any other hwmon energy source; it
+never touches SPBM, ACPI, or the MediaTek interface directly.
+
+- **Energy source: the accumulator, not the power reading.** The provider reads
+  the cumulative energy counter (`energyN_input`) at window boundaries and
+  differences it — the same pattern as NVML and RAPL. It deliberately does *not*
+  integrate the instantaneous power channel: the firmware's ~100 ms PID control
+  loop makes instantaneous power oscillate, whereas the accumulator already
+  integrates correctly in firmware.
+- **Rail selection.** It sums the rails that constitute host energy — the
+  top-level `package` rail plus a DRAM-equivalent rail if exposed separately —
+  identifying each by its `energyN_label`. Per-core subsets (CPU performance /
+  efficiency cores) are excluded because they are already contained in `package`;
+  including them would double-count. Selection is by label, never by channel
+  index, and is configurable (`config.rails`, `config.exclude`).
+- **Chip discovery.** It walks `/sys/class/hwmon/hwmon*/name` for the chip name
+  the driver registers (configurable via `config.name`, default `spark` — confirm
+  on hardware). No match → unavailable with reason "spark_hwmon driver not loaded".
+- **Wraparound.** hwmon exposes no documented maximum for an energy counter (unlike
+  RAPL's `max_energy_range_uj`), so the wrap width is unknown until confirmed on
+  hardware. A counter that goes **backwards** within a window is reported as
+  unavailable for that window — never a negative and never a wrapped-large value.
+- **Never zero, applied to hwmon.** A read that does not parse as a number is
+  unavailable (guarding hwmon's "non-number reads as 0" hazard); an absent driver
+  is unavailable; a backwards counter is unavailable. Only a clean, monotonic,
+  parseable delta becomes a reading.
+- **Unit.** The accumulator is documented in millijoules; standard hwmon energy is
+  microjoules. Because the ABI is in flux this is configurable — `config.energy_unit`
+  is `mj` (default) or `uj` — so the scale can be corrected without a rebuild.
+- **Firmware correctness — operator's responsibility.** Older firmware reports
+  incorrect values on the CPU power channels; the fix is a BIOS update via `fwupd`.
+  The provider *cannot* detect stale firmware. Readings from this path carry the
+  metric label `provider="grace-spark-hwmon"` so an operator can segregate
+  experimental-path data from `rapl` / `grace-hwmon` in Prometheus.
+
+What this provider does **not** do: it does not bundle or manage the driver; it
+does not touch the driver's writable `power_cap` / PL1 / PL2 controls (those are
+mutations — clock/power capping — and belong behind the measure/decide/enforce
+boundary in Aitra Policy, exactly as DVFS does); and it does not promote GB10 host
+energy to a supported tier.
+
+```yaml
+hostEnergyProvider:
+  type: grace-spark-hwmon   # EXPERIMENTAL — GB10 only, requires the community driver
+  config: {}                # optional: name, rails, exclude, energy_unit, path
+```
+
+> **Sizing the error, separately.** Even with this provider available, the primary
+> use of the Spark driver should be a one-off *benchmark* to quantify how wrong
+> GPU-only J/token is on this hardware — not a standing production dependency. A
+> measured example on a GB10 (one small–mid model, concurrency 8, eager mode): the
+> GPU drew ≈30 % of total box power, i.e. GPU-only J/token undercounted
+> whole-system energy by ≈3.3×, and — measured across the qwen2.5 0.5B→32B ladder
+> — that ratio was roughly **constant** rather than shrinking with model size.
+> Treat these as hardware- and load-specific: on a datacenter GPU drawing
+> 400–700 W the host share is far smaller.

--- a/docs/guides/host-energy.md
+++ b/docs/guides/host-energy.md
@@ -1,0 +1,121 @@
+# Host energy measurement
+
+`aitra_j_per_token` measures **accelerator** energy only. Everything else the
+node does to serve a token — tokenization, detokenization, sampling, request
+scheduling, KV-cache management, and the HTTP path — runs on the host and, by
+default, is unmeasured. Host energy measurement (issue #82) closes that gap
+**without** redefining `aitra_j_per_token`.
+
+With a host-energy provider configured, the agent also measures non-accelerator
+energy per window and the aggregation service emits
+[`aitra_system_j_per_token`](../reference/metrics.md#aitra_system_j_per_token)
+and [`aitra_host_energy_fraction`](../reference/metrics.md#aitra_host_energy_fraction).
+
+## The one rule: absent is not zero
+
+**A node with no host telemetry reports the host metrics as _absent_, never as
+`0`.**
+
+A zero would be silently wrong in the worst direction: it would understate
+`aitra_system_j_per_token` and make an *unmeasured* node look **more efficient**
+than a measured one. Two clusters would be incomparable, and the more honest one
+would look worse. So:
+
+- Providers return `ErrHostEnergyUnavailable` (with a reason) on hardware with no
+  telemetry — never a zero reading.
+- The aggregation service **omits** the host metrics for that node.
+- The agent logs the unavailability **once at startup**, with the reason, at INFO.
+- The storage record's `host_energy_joules` is SQL `NULL`, not `0`.
+
+## `host`, not `cpu`
+
+The metric family is named `host`, not `cpu`, on purpose. RAPL exposes *domains*
+(`package`, `dram`, `core`, `uncore`, `psys`) — and DRAM is not the CPU at all,
+yet it is a material share of inference host energy. More importantly, `host`
+names a **boundary** (the accelerator versus everything else on the node) rather
+than a component, so it survives non-x86 hardware and board-level paths
+(BMC/Redfish) that also capture NICs, storage, fans, and PSU losses. RAPL is one
+*provider* of host energy, exactly as NVML is one provider of accelerator energy.
+
+## Provider matrix
+
+| Platform | Provider | Source | Status |
+|---|---|---|---|
+| x86 (Intel, AMD) | `rapl` | `/sys/class/powercap/intel-rapl:*/energy_uj` | Supported |
+| Grace Superchip (72-core) | `grace-hwmon` | hwmon `power1_average` / `power1_oem_info` | Supported |
+| GB10 / DGX Spark | — | none | **Unavailable, by design** |
+| Server-class, any arch | `redfish` | BMC | Future |
+| Default | `none` | Noop (metrics omitted) | Supported |
+
+Configure via Helm:
+
+```yaml
+hostEnergyProvider:
+  type: rapl   # rapl | grace-hwmon | none
+  config: {}
+```
+
+or directly on the agent: `--host-energy-provider=rapl`.
+
+## `rapl` (x86)
+
+Reads and differences `/sys/class/powercap/intel-rapl:*/energy_uj`. Pure Go, no
+cgo, no sidecar. Notes:
+
+- **Domains.** It sums each `package-N` domain and its `dram` subdomain,
+  identified by reading each directory's `name` file. `core`/`uncore` are
+  excluded (subsets of `package` — including them double-counts); `psys` is
+  excluded (a platform superset that overlaps `package`).
+- **Counter wraparound.** `energy_uj` wraps at `max_energy_range_uj`; at high
+  power the counter can wrap within a window. The provider detects `end < start`
+  and adds the range. This is the most likely source of a silent correctness bug
+  in a RAPL reader — it is unit-tested explicitly.
+- **Permissions.** On many distributions `energy_uj` is `0400 root` following
+  CVE-2020-8694. The DaemonSet must read it as root or have the file
+  group-readable. If the file exists but is unreadable, that is reported as
+  unavailable (with a distinct reason), never as a crash and never as zero.
+- **Container visibility.** `/sys/class/powercap` must be visible inside the pod;
+  it may need an explicit `hostPath` mount. Verify in a real pod.
+- **AMD** exposes the same interface under `intel-rapl` naming on recent kernels;
+  the provider enumerates rather than hardcoding paths.
+
+## `grace-hwmon` (Grace Superchip, 72-core)
+
+Reads the CPU power rails documented in the NVIDIA Grace Performance Tuning
+Guide. The correct rail is found by reading `powerN_oem_info` (e.g.
+`"CPU Power Socket 0"`), never by index. Because `powerN_average` is a **power**
+reading in microwatts (not an energy counter), this provider integrates power
+over the window rather than differencing a counter. Requires
+`CONFIG_SENSORS_ACPI_POWER`; if the hwmon rails are absent it reports
+unavailable.
+
+## GB10 / DGX Spark — unavailable, deliberately
+
+NVIDIA has stated on the developer forum (2026-02-20) that Spark's power
+management differs from the 72-core Grace CPU, that there is **no method to
+monitor CPU power**, and that there are no plans to expose CPU rail information.
+`nvidia-smi` reports GPU power only. Independently verified as absent on Spark:
+the ACPI power meter, hwmon power attributes (`power1_input`, `power1_average`,
+`power1_oem_info`), SCMI power domains, and a BMC (Spark has none, so
+Redfish/IPMI is not an option either).
+
+A community out-of-tree kernel driver (`antheas/spark_hwmon`) reaches the
+MediaTek SSPM firmware's shared memory and does expose cumulative energy counters
+in millijoules through standard hwmon. **Aitra Meter does not take a dependency on
+it.** It is unsigned and out-of-tree, needs DKMS and MOK keys under Secure Boot,
+is self-described by its author as "vibe coded", and its firmware ABI is
+explicitly still in flux. Building a shipped provider on an unstable ABI, or
+asking users to install such a driver, is not a reasonable ask.
+
+On GB10, host energy is `unavailable`, and Aitra Meter says so. That is the
+honest state — and it is a stronger position than silently reporting a wrong
+number.
+
+> **Sizing the error, separately.** For a one-off *benchmark* (not a shipped
+> path), `antheas/spark_hwmon` can be installed on a GB10 to quantify how large
+> the host share actually is. A measured example on a GB10 (one small–mid model,
+> concurrency 8, eager mode): the GPU drew ≈30 % of total box power, i.e. GPU-only
+> J/token undercounted whole-system energy by ≈3.3×, and — measured across the
+> qwen2.5 0.5B→32B ladder — that ratio was roughly **constant** rather than
+> shrinking with model size. Treat these as hardware- and load-specific: on a
+> datacenter GPU drawing 400–700 W the host share is far smaller.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -83,7 +83,7 @@ Metrics are exposed at:
 
 **Type:** Gauge  
 **Source:** Aggregation service  
-**Description:** Joules per output token for the current measurement window. The primary Aitra Meter metric.
+**Description:** Joules per output token for the current measurement window. The primary Aitra Meter metric. **This is accelerator (GPU) energy only** — it does not include host energy (CPU package, DRAM, board). For whole-node energy per token, see [`aitra_system_j_per_token`](#aitra_system_j_per_token), which is emitted when a host-energy provider is configured. The definition of this metric is unchanged: anyone with a baseline keeps it.
 
 | Label | Description |
 |---|---|
@@ -300,6 +300,81 @@ Metrics are exposed at:
 | Label | Description |
 |---|---|
 | `node` | Kubernetes node name |
+
+---
+
+## Host energy metrics (#82)
+
+Host energy is everything on the node that is **not** the accelerator: CPU
+package, DRAM, and — depending on the provider — the wider board (NICs, storage,
+fans, PSU losses). It is measured per node by a host-energy provider (`rapl` on
+x86, `grace-hwmon` on the Grace Superchip); see the
+[host energy guide](../guides/host-energy.md).
+
+> **Absent is not zero.** Every metric in this section is **omitted entirely** on
+> nodes without host telemetry — it is never emitted as `0`. A zero would
+> understate whole-node efficiency and make an *unmeasured* node look **more
+> efficient** than a measured one, so the two would be incomparable and the more
+> honest node would look worse. On GB10 / DGX Spark, which exposes no host power
+> telemetry, these metrics do not exist.
+
+### `aitra_host_energy_joules_total`
+
+**Type:** Counter  
+**Source:** Aggregation service  
+**Description:** Cumulative host (non-accelerator) energy consumed, in joules. **Absent** on nodes without host telemetry.
+
+| Label | Description |
+|---|---|
+| `node` | Kubernetes node name |
+| `provider` | Host energy provider: `rapl`, `grace-hwmon` |
+| `domain` | Energy domain (`all` for the summed node total) |
+
+---
+
+### `aitra_host_power_watts`
+
+**Type:** Gauge  
+**Source:** Aggregation service  
+**Description:** Current host (non-accelerator) power draw in watts. **Absent** on nodes without host telemetry.
+
+| Label | Description |
+|---|---|
+| `node` | Kubernetes node name |
+| `provider` | Host energy provider: `rapl`, `grace-hwmon` |
+
+---
+
+### `aitra_system_j_per_token`
+
+**Type:** Gauge  
+**Source:** Aggregation service  
+**Description:** Total system energy per output token: `(gpu_energy + host_energy) / output_tokens`. The whole-node counterpart to [`aitra_j_per_token`](#aitra_j_per_token). **Absent** on nodes without host telemetry — never falls back to the GPU-only figure.
+
+| Label | Description |
+|---|---|
+| `namespace` | Kubernetes namespace |
+| `workload` | Workload type: `chat`, `code`, `reasoning`, `batch`, `unknown` |
+| `model` | Model name |
+| `hardware` | GPU tier from node label |
+| `precision` | Precision from pod annotation |
+| `calibration_tier` | `aitra_benchmark`, `reference`, `self_calibrated`, `uncalibrated` |
+| `attribution_method` | `direct` or `proportional` |
+| `host_provider` | Host energy provider that supplied the host term |
+
+---
+
+### `aitra_host_energy_fraction`
+
+**Type:** Gauge  
+**Source:** Aggregation service  
+**Description:** Fraction of a workload's energy consumed **outside** the accelerator: `host_energy / (gpu_energy + host_energy)`. A serving deployment burning a large fraction outside the GPU is likely misconfigured — a signal that is otherwise invisible. **Absent** on nodes without host telemetry.
+
+| Label | Description |
+|---|---|
+| `node` | Kubernetes node name |
+| `model` | Model name |
+| `namespace` | Kubernetes namespace |
 
 ---
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -308,15 +308,18 @@ Metrics are exposed at:
 Host energy is everything on the node that is **not** the accelerator: CPU
 package, DRAM, and — depending on the provider — the wider board (NICs, storage,
 fans, PSU losses). It is measured per node by a host-energy provider (`rapl` on
-x86, `grace-hwmon` on the Grace Superchip); see the
-[host energy guide](../guides/host-energy.md).
+x86, `grace-hwmon` on the Grace Superchip, and the experimental opt-in
+`grace-spark-hwmon` on GB10 / DGX Spark via a community driver); see the
+[host energy guide](../guides/host-energy.md). The `provider` label distinguishes
+these paths so experimental-path data is segregable in Prometheus.
 
 > **Absent is not zero.** Every metric in this section is **omitted entirely** on
 > nodes without host telemetry — it is never emitted as `0`. A zero would
 > understate whole-node efficiency and make an *unmeasured* node look **more
 > efficient** than a measured one, so the two would be incomparable and the more
-> honest node would look worse. On GB10 / DGX Spark, which exposes no host power
-> telemetry, these metrics do not exist.
+> honest node would look worse. On a stock GB10 / DGX Spark, which exposes no host
+> power telemetry, these metrics do not exist — unless the operator has opted into
+> the experimental `grace-spark-hwmon` community-driver path.
 
 ### `aitra_host_energy_joules_total`
 
@@ -327,7 +330,7 @@ x86, `grace-hwmon` on the Grace Superchip); see the
 | Label | Description |
 |---|---|
 | `node` | Kubernetes node name |
-| `provider` | Host energy provider: `rapl`, `grace-hwmon` |
+| `provider` | Host energy provider: `rapl`, `grace-hwmon`, `grace-spark-hwmon` (experimental) |
 | `domain` | Energy domain (`all` for the summed node total) |
 
 ---
@@ -341,7 +344,7 @@ x86, `grace-hwmon` on the Grace Superchip); see the
 | Label | Description |
 |---|---|
 | `node` | Kubernetes node name |
-| `provider` | Host energy provider: `rapl`, `grace-hwmon` |
+| `provider` | Host energy provider: `rapl`, `grace-hwmon`, `grace-spark-hwmon` (experimental) |
 
 ---
 

--- a/helm/aitra-meter/templates/measurement-agent.yaml
+++ b/helm/aitra-meter/templates/measurement-agent.yaml
@@ -94,7 +94,8 @@ spec:
             periodSeconds: 10
           {{- end }}
           {{- $rapl := eq .Values.measurementAgent.hostEnergyProvider.type "rapl" }}
-          {{- if or .Values.measurementAgent.nvml.hostLibraryPath $rapl }}
+          {{- $hwmon := or (eq .Values.measurementAgent.hostEnergyProvider.type "grace-hwmon") (eq .Values.measurementAgent.hostEnergyProvider.type "grace-spark-hwmon") }}
+          {{- if or .Values.measurementAgent.nvml.hostLibraryPath $rapl $hwmon }}
           volumeMounts:
             {{- if .Values.measurementAgent.nvml.hostLibraryPath }}
             - name: nvml-lib
@@ -108,8 +109,16 @@ spec:
               mountPath: /sys/class/powercap
               readOnly: true
             {{- end }}
+            {{- if $hwmon }}
+            # grace-hwmon / grace-spark-hwmon read /sys/class/hwmon. Mounted
+            # explicitly so the power rails / energy accumulators are visible in the
+            # pod rather than relying on the default /sys mount.
+            - name: hwmon
+              mountPath: /sys/class/hwmon
+              readOnly: true
+            {{- end }}
           {{- end }}
-      {{- if or .Values.measurementAgent.nvml.hostLibraryPath $rapl }}
+      {{- if or .Values.measurementAgent.nvml.hostLibraryPath $rapl $hwmon }}
       volumes:
         {{- if .Values.measurementAgent.nvml.hostLibraryPath }}
         - name: nvml-lib
@@ -121,6 +130,12 @@ spec:
         - name: powercap
           hostPath:
             path: /sys/class/powercap
+            type: Directory
+        {{- end }}
+        {{- if $hwmon }}
+        - name: hwmon
+          hostPath:
+            path: /sys/class/hwmon
             type: Directory
         {{- end }}
       {{- end }}

--- a/helm/aitra-meter/templates/measurement-agent.yaml
+++ b/helm/aitra-meter/templates/measurement-agent.yaml
@@ -41,7 +41,13 @@ spec:
           imagePullPolicy: {{ .Values.measurementAgent.image.pullPolicy }}
           args:
             - --energy-provider={{ .Values.measurementAgent.energyProvider.type }}
+            {{- with .Values.measurementAgent.hostEnergyProvider }}
+            - --host-energy-provider={{ .type }}
+            {{- end }}
             - --inference-provider={{ .Values.measurementAgent.inferenceProvider.type }}
+            {{- if .Values.measurementAgent.inferenceProvider.config.endpoint }}
+            - --inference-endpoint={{ .Values.measurementAgent.inferenceProvider.config.endpoint }}
+            {{- end }}
             - --aggregator={{ include "aitra-meter.fullname" . }}-aggregation-service:9091
             - --log-level=info
           env:
@@ -53,6 +59,16 @@ spec:
             - name: INFERENCE_ENDPOINT
               value: {{ .Values.measurementAgent.inferenceProvider.config.endpoint | quote }}
             {{- end }}
+            {{- if .Values.measurementAgent.nvml.hostLibraryPath }}
+            # Driver-matched NVML library injected via hostPath (kind/bare-metal
+            # nodes where the container runtime does not auto-mount driver libs).
+            # LD_PRELOAD loads it at process start so go-nvml's cgo symbols bind
+            # correctly (a plain dlopen after startup leaves the GOT slot at 0).
+            - name: LD_PRELOAD
+              value: /opt/nvml/libnvidia-ml.so.1
+            - name: LD_LIBRARY_PATH
+              value: /opt/nvml
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 9090
@@ -61,6 +77,9 @@ spec:
             privileged: true
           resources:
             {{- toYaml .Values.measurementAgent.resources | nindent 12 }}
+          {{- if .Values.measurementAgent.httpProbes }}
+          # The agent is a gRPC-push loop with no HTTP server in this build; probes
+          # are opt-in and only valid once an HTTP metrics/health server is wired in.
           livenessProbe:
             httpGet:
               path: /healthz
@@ -73,6 +92,38 @@ spec:
               port: 9090
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- end }}
+          {{- $rapl := eq .Values.measurementAgent.hostEnergyProvider.type "rapl" }}
+          {{- if or .Values.measurementAgent.nvml.hostLibraryPath $rapl }}
+          volumeMounts:
+            {{- if .Values.measurementAgent.nvml.hostLibraryPath }}
+            - name: nvml-lib
+              mountPath: /opt/nvml/libnvidia-ml.so.1
+              readOnly: true
+            {{- end }}
+            {{- if $rapl }}
+            # RAPL reads /sys/class/powercap. Mounted explicitly so the counters
+            # are visible in the pod rather than relying on the default /sys mount.
+            - name: powercap
+              mountPath: /sys/class/powercap
+              readOnly: true
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.measurementAgent.nvml.hostLibraryPath $rapl }}
+      volumes:
+        {{- if .Values.measurementAgent.nvml.hostLibraryPath }}
+        - name: nvml-lib
+          hostPath:
+            path: {{ .Values.measurementAgent.nvml.hostLibraryPath }}
+            type: File
+        {{- end }}
+        {{- if $rapl }}
+        - name: powercap
+          hostPath:
+            path: /sys/class/powercap
+            type: Directory
+        {{- end }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -46,14 +46,23 @@ measurementAgent:
   # aitra_j_per_token measures GPU energy only. With a host provider configured,
   # aitra_system_j_per_token reports total system energy per token.
   #
-  #   rapl         x86 (Intel and AMD). Reads /sys/class/powercap.
-  #   grace-hwmon  Grace Superchip (72-core). Reads hwmon power rails.
-  #   none         No host measurement. Host metrics are omitted, not zeroed.
+  #   rapl               x86 (Intel and AMD). Reads /sys/class/powercap.
+  #   grace-hwmon        Grace Superchip (72-core). Reads hwmon power rails.
+  #   grace-spark-hwmon  EXPERIMENTAL. NVIDIA GB10 / DGX Spark only. Reads the
+  #                      cumulative energy accumulator exposed by the community
+  #                      antheas/spark_hwmon kernel driver. Aitra does NOT install,
+  #                      sign, or manage that driver — the operator must install it
+  #                      (DKMS + MOK under Secure Boot) and keep firmware current.
+  #                      Driver absent -> host metrics are omitted (never zeroed).
+  #                      Readings carry provider="grace-spark-hwmon" so they can be
+  #                      told apart from the supported rapl / grace-hwmon paths.
+  #   none               No host measurement. Host metrics are omitted, not zeroed.
   #
-  # Not available on all hardware. NVIDIA GB10 / DGX Spark exposes no host power
-  # telemetry, so host metrics are omitted there. This is reported as unavailable
-  # and never as zero: a zero would make an unmeasured node look more efficient
-  # than a measured one. See docs/guides/host-energy.md.
+  # Not available on all hardware. On a stock NVIDIA GB10 / DGX Spark (no community
+  # driver) there is no host power telemetry, so host metrics are omitted there.
+  # Absence is always reported as unavailable and never as zero: a zero would make
+  # an unmeasured node look more efficient than a measured one. See
+  # docs/guides/host-energy.md.
   hostEnergyProvider:
     type: none
     config: {}

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -40,6 +40,33 @@ measurementAgent:
   energyProvider:
     type: nvml
     config: {}
+  # Host energy — energy consumed by everything on the node that is not the
+  # accelerator (CPU package, DRAM, and depending on platform the wider board).
+  #
+  # aitra_j_per_token measures GPU energy only. With a host provider configured,
+  # aitra_system_j_per_token reports total system energy per token.
+  #
+  #   rapl         x86 (Intel and AMD). Reads /sys/class/powercap.
+  #   grace-hwmon  Grace Superchip (72-core). Reads hwmon power rails.
+  #   none         No host measurement. Host metrics are omitted, not zeroed.
+  #
+  # Not available on all hardware. NVIDIA GB10 / DGX Spark exposes no host power
+  # telemetry, so host metrics are omitted there. This is reported as unavailable
+  # and never as zero: a zero would make an unmeasured node look more efficient
+  # than a measured one. See docs/guides/host-energy.md.
+  hostEnergyProvider:
+    type: none
+    config: {}
+  # NVML library injection (optional). On managed GPU nodes the container runtime
+  # mounts libnvidia-ml.so.1 automatically. On kind / bare-metal nodes where it
+  # does not, point this at a driver-matched libnvidia-ml.so.1 present on the node
+  # and the DaemonSet will mount it into the agent at /opt/nvml (added to
+  # LD_LIBRARY_PATH). Leave empty to disable.
+  nvml:
+    hostLibraryPath: ""
+  # The agent is a gRPC-push loop with no HTTP server in this build. Leave false
+  # unless a build wires an HTTP health/metrics server on the metrics port.
+  httpProbes: false
   # dcgm example (scrape a node-local dcgm-exporter instead of reading NVML in-process):
   # energyProvider:
   #   type: dcgm

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -52,6 +52,12 @@ type Config struct {
 	// EnergyProvider and InferenceProvider are the measurement backends.
 	EnergyProvider    provider.EnergyProvider
 	InferenceProvider provider.InferenceMetricsProvider
+
+	// HostEnergyProvider measures non-accelerator (CPU/DRAM/board) energy. It is
+	// optional: when nil, or when it reports Available()==false, host energy is
+	// omitted from every WindowReport — the field is left unset (not zero) so the
+	// aggregation service can distinguish "not measured" from "measured zero".
+	HostEnergyProvider provider.HostEnergyProvider
 }
 
 // Loop runs the measurement loop for a single node.
@@ -67,6 +73,14 @@ type Loop struct {
 	seenFirstToken bool
 	// windowSeq is a monotonic counter for window IDs.
 	windowSeq uint64
+
+	// hostAvailable is resolved once at construction from HostEnergyProvider
+	// .Available(). When false, no host window is opened and no host field is set.
+	hostAvailable bool
+	// hostBegun records whether the current window's host BeginWindow succeeded,
+	// so reportWindow only ends a window it actually started. The loop is a single
+	// goroutine (begin → wait → report), so a plain field is safe here.
+	hostBegun bool
 }
 
 // New creates a Loop and dials the aggregation service. Call Run to start.
@@ -89,12 +103,32 @@ func New(cfg Config, log *zap.Logger) (*Loop, error) {
 		return nil, fmt.Errorf("dial aggregation service %q: %w", cfg.AggregatorAddr, err)
 	}
 
-	return &Loop{
+	l := &Loop{
 		cfg:    cfg,
 		log:    log,
 		client: measurementv1.NewMeasurementServiceClient(conn),
 		conn:   conn,
-	}, nil
+	}
+
+	// Resolve host-energy capability exactly once, and log it once at INFO — not
+	// per window (that is log spam that gets filtered, defeating the purpose).
+	if cfg.HostEnergyProvider != nil {
+		l.hostAvailable = cfg.HostEnergyProvider.Available(context.Background())
+		if l.hostAvailable {
+			log.Info("host energy measurement enabled",
+				zap.String("host_provider", cfg.HostEnergyProvider.Name()))
+		} else {
+			reason := "provider reports no host telemetry on this hardware"
+			if n, ok := cfg.HostEnergyProvider.(*provider.NoopHostEnergy); ok {
+				reason = n.Reason
+			}
+			log.Info("host energy unavailable — system J/token will be omitted, never zeroed",
+				zap.String("host_provider", cfg.HostEnergyProvider.Name()),
+				zap.String("reason", reason))
+		}
+	}
+
+	return l, nil
 }
 
 // Close releases the gRPC connection.
@@ -130,6 +164,18 @@ func (l *Loop) Run(ctx context.Context) {
 				return
 			}
 			continue
+		}
+
+		// Open the host-energy window alongside the GPU window. A host failure
+		// never affects the GPU path: we simply omit host energy for this window.
+		l.hostBegun = false
+		if l.hostAvailable {
+			if err := l.cfg.HostEnergyProvider.BeginWindow(ctx, windowID); err != nil {
+				l.log.Debug("host BeginWindow failed — host energy omitted this window",
+					zap.String("window_id", windowID), zap.Error(err))
+			} else {
+				l.hostBegun = true
+			}
 		}
 
 		// Wait for the window to elapse.
@@ -188,6 +234,22 @@ func (l *Loop) reportWindow(ctx context.Context, windowID string) {
 		EnergyProvider:    l.cfg.EnergyProvider.Name(),
 		InferenceProvider: l.cfg.InferenceProvider.Name(),
 		TimestampUnixMs:   time.Now().UnixMilli(),
+	}
+
+	// Close the host-energy window, if one was opened. On success the fields are
+	// set (presence = measured); on failure they are left unset (nil), which the
+	// aggregation service reads as "not measured" — never as a zero reading.
+	if l.hostBegun {
+		hostJoules, herr := l.cfg.HostEnergyProvider.EndWindow(ctx, windowID)
+		if herr != nil {
+			l.log.Debug("host EndWindow failed — host energy omitted this window",
+				zap.String("window_id", windowID), zap.Error(herr))
+		} else {
+			hostPower := hostJoules / l.cfg.WindowDuration.Seconds()
+			report.HostEnergyJoules = &hostJoules
+			report.HostPowerWatts = &hostPower
+			report.HostProvider = l.cfg.HostEnergyProvider.Name()
+		}
 	}
 
 	ack, err := l.client.ReportWindow(ctx, report)

--- a/internal/aggregation/loop.go
+++ b/internal/aggregation/loop.go
@@ -174,6 +174,33 @@ func (l *Loop) ReportWindow(
 
 	metrics.GPUPowerWatts.WithLabelValues(w.Node, "all").Set(w.PowerWatts)
 
+	// --- host energy (issue #82) -------------------------------------------
+	// Present only when the agent actually measured it. Absence is emitted as
+	// absence: no host metric is written, and aitra_system_j_per_token /
+	// aitra_host_energy_fraction simply do not exist for this node. Never zero —
+	// a zero would make an unmeasured node look more efficient than a measured
+	// one. The GPU path above is entirely unaffected by host presence.
+	var hostRec *float64
+	if w.HostEnergyJoules != nil {
+		hostJ := *w.HostEnergyJoules
+		hp := w.HostProvider
+		metrics.HostEnergyJoulesTotal.WithLabelValues(w.Node, hp, "all").Add(hostJ)
+		if w.HostPowerWatts != nil {
+			metrics.HostPowerWatts.WithLabelValues(w.Node, hp).Set(*w.HostPowerWatts)
+		}
+		systemJ := w.EnergyJoules + hostJ
+		metrics.SystemJPerToken.WithLabelValues(
+			attr.Namespace, attr.Workload, w.ModelName, hw,
+			attr.Precision, tier, method, hp,
+		).Set(systemJ / float64(w.OutputTokens))
+		if systemJ > 0 {
+			metrics.HostEnergyFraction.WithLabelValues(w.Node, w.ModelName, attr.Namespace).
+				Set(hostJ / systemJ)
+		}
+		v := hostJ // copy: do not alias the proto message's pointer into storage
+		hostRec = &v
+	}
+
 	// --- storage record -------------------------------------------------
 	ts := w.TimestampUnixMs
 	if ts == 0 {
@@ -200,6 +227,7 @@ func (l *Loop) ReportWindow(
 		Stable:            stable,
 		EnergyProvider:    w.EnergyProvider,
 		InferenceProvider: w.InferenceProvider,
+		HostEnergyJoules:  hostRec,
 	}
 	_ = l.writer.Write(ctx, rec) // async writers never block; errors are logged by the writer
 

--- a/internal/aggregation/loop_test.go
+++ b/internal/aggregation/loop_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	measurementv1 "github.com/aitra-ai/aitra-meter/api/proto/measurement/v1"
@@ -91,6 +92,114 @@ func baseReport() *measurementv1.WindowReport {
 		EnergyProvider:    "nvml",
 		InferenceProvider: "vllm",
 		TimestampUnixMs:   1716000000000,
+	}
+}
+
+// gatheredSample searches the default Prometheus gatherer for a sample of metric
+// `name` whose labels include all of labelWant. It reads without touching
+// WithLabelValues, which would itself create a zero series and defeat an absence
+// check. Returns (found, value).
+func gatheredSample(t *testing.T, name string, labelWant map[string]string) (bool, float64) {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			have := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				have[lp.GetName()] = lp.GetValue()
+			}
+			match := true
+			for k, v := range labelWant {
+				if have[k] != v {
+					match = false
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+			if m.Gauge != nil {
+				return true, m.Gauge.GetValue()
+			}
+			if m.Counter != nil {
+				return true, m.Counter.GetValue()
+			}
+			return true, 0
+		}
+	}
+	return false, 0
+}
+
+// TestLoopHostEnergyPresent verifies that when a window carries host energy, the
+// system J/token and host-energy-fraction metrics are emitted with the right
+// values and the storage record carries the measured joules.
+func TestLoopHostEnergyPresent(t *testing.T) {
+	loop, sink := newTestLoop(nil, PolicyConfig{}, nil)
+	w := baseReport()
+	w.ModelName = "hosttest-present"
+	hostJ := 100.0
+	hostW := 3.3
+	w.HostEnergyJoules = &hostJ
+	w.HostPowerWatts = &hostW
+	w.HostProvider = "rapl"
+
+	if _, err := loop.ReportWindow(context.Background(), w); err != nil {
+		t.Fatal(err)
+	}
+
+	wantSystem := (w.EnergyJoules + hostJ) / float64(w.OutputTokens)
+	found, got := gatheredSample(t, "aitra_system_j_per_token", map[string]string{
+		"model": "hosttest-present", "host_provider": "rapl",
+	})
+	if !found {
+		t.Fatal("aitra_system_j_per_token not emitted when host energy present")
+	}
+	if math.Abs(got-wantSystem) > 1e-9 {
+		t.Fatalf("system J/token = %v, want %v", got, wantSystem)
+	}
+
+	wantFrac := hostJ / (w.EnergyJoules + hostJ)
+	found, got = gatheredSample(t, "aitra_host_energy_fraction", map[string]string{"model": "hosttest-present"})
+	if !found || math.Abs(got-wantFrac) > 1e-9 {
+		t.Fatalf("host_energy_fraction found=%v got=%v want %v", found, got, wantFrac)
+	}
+
+	if rec := sink.last(); rec.HostEnergyJoules == nil || *rec.HostEnergyJoules != hostJ {
+		t.Fatalf("record HostEnergyJoules = %v, want %v", rec.HostEnergyJoules, hostJ)
+	}
+}
+
+// TestLoopHostEnergyAbsentIsNotZero is the test that protects the central
+// contract: a window WITHOUT host energy must not emit aitra_system_j_per_token
+// or aitra_host_energy_fraction at all — not as zero. A zero would make an
+// unmeasured node look more efficient than a measured one.
+func TestLoopHostEnergyAbsentIsNotZero(t *testing.T) {
+	loop, sink := newTestLoop(nil, PolicyConfig{}, nil)
+	w := baseReport()
+	w.ModelName = "hosttest-absent" // no HostEnergyJoules set
+
+	if _, err := loop.ReportWindow(context.Background(), w); err != nil {
+		t.Fatal(err)
+	}
+
+	if found, v := gatheredSample(t, "aitra_system_j_per_token", map[string]string{"model": "hosttest-absent"}); found {
+		t.Fatalf("aitra_system_j_per_token emitted (value %v) for a node without host telemetry — must be absent, never zero", v)
+	}
+	if found, v := gatheredSample(t, "aitra_host_energy_fraction", map[string]string{"model": "hosttest-absent"}); found {
+		t.Fatalf("aitra_host_energy_fraction emitted (value %v) for a node without host telemetry — must be absent", v)
+	}
+	if rec := sink.last(); rec.HostEnergyJoules != nil {
+		t.Fatalf("record HostEnergyJoules = %v, want nil (not measured)", *rec.HostEnergyJoules)
+	}
+	// The GPU-only metric MUST still be present and unchanged.
+	if found, _ := gatheredSample(t, "aitra_j_per_token", map[string]string{"model": "hosttest-absent"}); !found {
+		t.Fatal("aitra_j_per_token must still be emitted (GPU path unaffected by host absence)")
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -150,4 +150,43 @@ var (
 		Name: "aitra_gpu_serving_utilization_ratio",
 		Help: "Fraction of elapsed time the node was serving inference requests (0.0-1.0).",
 	}, []string{"node"})
+
+	// --- Host energy (issue #82) --------------------------------------------
+	// Everything on the node that is not the accelerator: CPU package, DRAM, and
+	// depending on the provider the wider board. ALL of these metrics are ABSENT
+	// on nodes without host telemetry — never emitted as zero. A zero would
+	// understate aitra_system_j_per_token and make an unmeasured node look more
+	// efficient than a measured one. See internal/aggregation/loop.go, where every
+	// write below is guarded on host-energy presence.
+
+	// HostEnergyJoulesTotal is cumulative host (non-accelerator) energy in joules.
+	// Absent on nodes without host telemetry.
+	HostEnergyJoulesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aitra_host_energy_joules_total",
+		Help: "Cumulative host (non-accelerator) energy consumed in joules. Absent on nodes without host telemetry — never zero.",
+	}, []string{"node", "provider", "domain"})
+
+	// HostPowerWatts is current host (non-accelerator) power draw.
+	// Absent on nodes without host telemetry.
+	HostPowerWatts = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_host_power_watts",
+		Help: "Current host (non-accelerator) power draw in watts. Absent on nodes without host telemetry — never zero.",
+	}, []string{"node", "provider"})
+
+	// SystemJPerToken is (gpu_energy + host_energy) / output_tokens — the whole-node
+	// energy cost of a token. Absent on nodes without host telemetry, so that a node
+	// missing host measurement is incomparable rather than falsely flattering.
+	SystemJPerToken = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_system_j_per_token",
+		Help: "Total system (accelerator + host) joules per output token. Absent on nodes without host telemetry — never GPU-only.",
+	}, []string{"namespace", "workload", "model", "hardware", "precision", "calibration_tier", "attribution_method", "host_provider"})
+
+	// HostEnergyFraction is host_energy / (gpu_energy + host_energy): how much of a
+	// workload's energy is not going into the accelerator. A serving deployment
+	// burning a large fraction outside the GPU is misconfigured, and today that is
+	// invisible. Absent on nodes without host telemetry.
+	HostEnergyFraction = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "aitra_host_energy_fraction",
+		Help: "Fraction of total energy consumed outside the accelerator (host / (gpu+host)). Absent on nodes without host telemetry.",
+	}, []string{"node", "model", "namespace"})
 )

--- a/internal/model/record.go
+++ b/internal/model/record.go
@@ -25,19 +25,25 @@ const (
 // MeasurementRecord is the canonical schema for a single measurement window.
 // It is written to the storage backend and used in Prometheus metrics.
 type MeasurementRecord struct {
-	TimestampUnixMs   int64
-	Cluster           string
-	Node              string
-	Namespace         string
-	Workload          string
-	Model             string
-	Hardware          string
-	Precision         string
-	Team              string
-	CostCentre        string
-	EnergyJoules      float64
-	OutputTokens      uint64
-	JPerToken         float64
+	TimestampUnixMs int64
+	Cluster         string
+	Node            string
+	Namespace       string
+	Workload        string
+	Model           string
+	Hardware        string
+	Precision       string
+	Team            string
+	CostCentre      string
+	EnergyJoules    float64
+	OutputTokens    uint64
+	JPerToken       float64
+	// HostEnergyJoules is the non-accelerator (CPU package, DRAM, board) energy
+	// consumed during the window, in joules. It is a pointer, not a value, on
+	// purpose: nil means "not measured", which must never collapse to a zero
+	// reading — a zero would make an unmeasured node look more efficient than a
+	// measured one. See provider.ErrHostEnergyUnavailable.
+	HostEnergyJoules  *float64
 	CalibrationTier   CalibrationTier
 	RefJPerToken      float64
 	AttributionMethod AttributionMethod

--- a/internal/provider/host.go
+++ b/internal/provider/host.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrHostEnergyUnavailable is returned by a HostEnergyProvider on hardware that
+// exposes no host power telemetry. It is an error, never a zero reading.
+//
+// A zero would be silently wrong in the worst possible direction: it would
+// understate aitra_system_j_per_token and make an *unmeasured* node look more
+// efficient than a measured one. Preventing that is the single most important
+// invariant of this subsystem — every provider returns this error (wrapped with
+// a human-readable reason) rather than a zero when telemetry is absent.
+var ErrHostEnergyUnavailable = errors.New("host energy telemetry not available on this hardware")
+
+// HostEnergyProvider measures energy consumed by everything on the node that is
+// not the accelerator: the CPU package, DRAM, and — depending on platform and
+// provider — the wider board (NICs, storage, fans, PSU losses).
+//
+// The contract is deliberately identical in shape to EnergyProvider — a
+// monotonic energy counter, snapshotted at window boundaries and differenced —
+// so both sides of the node are measured the same way. RAPL is one provider of
+// host energy exactly as NVML is one provider of accelerator energy.
+//
+// "host" names a boundary (the accelerator versus everything else on the node),
+// not a component. That boundary survives non-x86 hardware and board-level
+// measurement paths (BMC/Redfish); "cpu" would not.
+type HostEnergyProvider interface {
+	// BeginWindow snapshots the host energy counters.
+	BeginWindow(ctx context.Context, windowID string) error
+
+	// EndWindow returns joules consumed by the host since BeginWindow.
+	// Returns ErrHostEnergyUnavailable on hardware with no host telemetry.
+	EndWindow(ctx context.Context, windowID string) (float64, error)
+
+	// IdlePower returns current host power draw in watts.
+	// Returns ErrHostEnergyUnavailable on hardware with no host telemetry.
+	IdlePower(ctx context.Context) (float64, error)
+
+	// Domains enumerates measurable host energy domains ("package-0", "dram-0").
+	Domains(ctx context.Context) ([]Device, error)
+
+	// Available reports whether this node exposes host energy telemetry. Called
+	// once at startup so the agent can log the capability and omit host metrics
+	// cleanly rather than emitting zeros.
+	Available(ctx context.Context) bool
+
+	// Name returns the provider identifier used in metric labels and logs.
+	Name() string
+}
+
+// HostEnergyProviderFactory creates a HostEnergyProvider from a config map.
+type HostEnergyProviderFactory func(config map[string]string) (HostEnergyProvider, error)
+
+var (
+	hostEnergyMu        sync.RWMutex
+	hostEnergyProviders = map[string]HostEnergyProviderFactory{}
+)
+
+// RegisterHostEnergy registers a HostEnergyProvider factory under a given name.
+// Call this from an init() function in your provider package.
+func RegisterHostEnergy(name string, factory HostEnergyProviderFactory) {
+	hostEnergyMu.Lock()
+	defer hostEnergyMu.Unlock()
+	hostEnergyProviders[name] = factory
+}
+
+// NewHostEnergy creates a HostEnergyProvider by name.
+func NewHostEnergy(name string, config map[string]string) (HostEnergyProvider, error) {
+	hostEnergyMu.RLock()
+	factory, ok := hostEnergyProviders[name]
+	hostEnergyMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown host energy provider %q — registered: %v", name, hostEnergyProviderNames())
+	}
+	return factory(config)
+}
+
+func hostEnergyProviderNames() []string {
+	hostEnergyMu.RLock()
+	defer hostEnergyMu.RUnlock()
+	names := make([]string, 0, len(hostEnergyProviders))
+	for n := range hostEnergyProviders {
+		names = append(names, n)
+	}
+	return names
+}
+
+// NoopHostEnergy is the HostEnergyProvider used when host telemetry is absent or
+// host measurement is switched off. Every read returns ErrHostEnergyUnavailable
+// wrapped with a human-readable reason. Nothing it returns is ever zero-as-data:
+// a zero reading is the one output this subsystem must never produce.
+type NoopHostEnergy struct {
+	// Reason explains why host energy is unavailable (e.g. "no host provider
+	// configured", "GB10/Spark exposes no host power telemetry"). It is included
+	// in every returned error and in the agent's one-time startup log line.
+	Reason string
+}
+
+// NewNoopHostEnergy returns a NoopHostEnergy carrying the given reason.
+func NewNoopHostEnergy(reason string) *NoopHostEnergy {
+	if reason == "" {
+		reason = "no host energy provider configured"
+	}
+	return &NoopHostEnergy{Reason: reason}
+}
+
+func (n *NoopHostEnergy) err() error {
+	return fmt.Errorf("%w: %s", ErrHostEnergyUnavailable, n.Reason)
+}
+
+// BeginWindow always fails: there is nothing to measure.
+func (n *NoopHostEnergy) BeginWindow(_ context.Context, _ string) error { return n.err() }
+
+// EndWindow always returns ErrHostEnergyUnavailable and never a zero reading.
+func (n *NoopHostEnergy) EndWindow(_ context.Context, _ string) (float64, error) {
+	return 0, n.err()
+}
+
+// IdlePower always returns ErrHostEnergyUnavailable and never a zero reading.
+func (n *NoopHostEnergy) IdlePower(_ context.Context) (float64, error) { return 0, n.err() }
+
+// Domains returns no domains.
+func (n *NoopHostEnergy) Domains(_ context.Context) ([]Device, error) { return nil, n.err() }
+
+// Available always reports false.
+func (n *NoopHostEnergy) Available(_ context.Context) bool { return false }
+
+// Name returns "none".
+func (n *NoopHostEnergy) Name() string { return "none" }
+
+func init() {
+	// "none" is the default provider: host metrics are omitted, never zeroed.
+	RegisterHostEnergy("none", func(config map[string]string) (HostEnergyProvider, error) {
+		return NewNoopHostEnergy(config["reason"]), nil
+	})
+}

--- a/internal/provider/hostenergy/gracehwmon/gracehwmon.go
+++ b/internal/provider/hostenergy/gracehwmon/gracehwmon.go
@@ -1,0 +1,207 @@
+//go:build linux
+
+// Package gracehwmon provides a HostEnergyProvider for the NVIDIA Grace Superchip
+// (72-core), reading CPU power rails from the hwmon interface documented in the
+// NVIDIA Grace Performance Tuning Guide.
+//
+// Unlike RAPL and NVML, the Grace hwmon interface exposes powerN_average — a
+// POWER reading in microwatts averaged over an interval — not a monotonic energy
+// counter. This provider therefore integrates power over the window (trapezoidal:
+// mean of the start and end average-power samples times the elapsed time) rather
+// than differencing a counter.
+//
+// The correct rail is identified by reading powerN_oem_info, which names the rail
+// (e.g. "CPU Power Socket 0"); rails are never selected by index. Requires
+// CONFIG_SENSORS_ACPI_POWER in the kernel. When the hwmon nodes are absent the
+// provider reports Available()==false and every read returns
+// provider.ErrHostEnergyUnavailable — never a zero reading.
+//
+// Note: this is the 72-core Grace Superchip, NOT the GB10 / DGX Spark. NVIDIA has
+// stated Spark exposes no host power telemetry, so on GB10 the "none" provider is
+// used and host energy is reported unavailable. See docs/guides/host-energy.md.
+package gracehwmon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+const (
+	defaultBasePath  = "/sys/class/hwmon"
+	defaultRailMatch = "CPU Power" // matched against powerN_oem_info (case-insensitive)
+)
+
+func init() {
+	provider.RegisterHostEnergy("grace-hwmon", func(config map[string]string) (provider.HostEnergyProvider, error) {
+		base := config["path"]
+		if base == "" {
+			base = defaultBasePath
+		}
+		match := config["rail_match"]
+		if match == "" {
+			match = defaultRailMatch
+		}
+		return newGrace(base, match), nil
+	})
+}
+
+// rail is one selected hwmon power rail.
+type rail struct {
+	label       string // from powerN_oem_info, e.g. "CPU Power Socket 0"
+	averagePath string // <hwmon>/powerN_average, microwatts
+}
+
+// GraceProvider implements provider.HostEnergyProvider over Grace hwmon rails.
+type GraceProvider struct {
+	rails         []rail
+	unavailReason string
+
+	mu      sync.Mutex
+	windows map[string]graceWindow
+}
+
+type graceWindow struct {
+	start      time.Time
+	startWatts float64
+}
+
+func newGrace(base, railMatch string) *GraceProvider {
+	rails, reason := discover(base, railMatch)
+	return &GraceProvider{rails: rails, unavailReason: reason, windows: make(map[string]graceWindow)}
+}
+
+// discover scans hwmon devices for powerN_oem_info files whose label contains
+// railMatch, and records the matching powerN_average paths.
+func discover(base, railMatch string) ([]rail, string) {
+	hwmons, err := filepath.Glob(filepath.Join(base, "hwmon*"))
+	if err != nil || len(hwmons) == 0 {
+		return nil, fmt.Sprintf("no hwmon devices under %s (CONFIG_SENSORS_ACPI_POWER / Grace power rails not present)", base)
+	}
+	match := strings.ToLower(railMatch)
+	var rails []rail
+	for _, h := range hwmons {
+		infos, _ := filepath.Glob(filepath.Join(h, "power*_oem_info"))
+		for _, info := range infos {
+			label, err := readTrim(info)
+			if err != nil {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(label), match) {
+				continue
+			}
+			// power<N>_oem_info -> power<N>_average
+			avg := strings.TrimSuffix(info, "_oem_info") + "_average"
+			if _, err := readUint(avg); err != nil {
+				continue
+			}
+			rails = append(rails, rail{label: label, averagePath: avg})
+		}
+	}
+	if len(rails) == 0 {
+		return nil, fmt.Sprintf("no hwmon power rail matching %q under %s", railMatch, base)
+	}
+	return rails, ""
+}
+
+func (p *GraceProvider) unavail() error {
+	return fmt.Errorf("%w: %s", provider.ErrHostEnergyUnavailable, p.unavailReason)
+}
+
+// sumWatts returns the summed instantaneous average power across all rails, in watts.
+func (p *GraceProvider) sumWatts() (float64, error) {
+	var totalUW uint64
+	for _, r := range p.rails {
+		uw, err := readUint(r.averagePath)
+		if err != nil {
+			return 0, fmt.Errorf("grace-hwmon read %s: %w", r.averagePath, err)
+		}
+		totalUW += uw
+	}
+	return float64(totalUW) / 1e6, nil
+}
+
+// BeginWindow records the start time and start power for later integration.
+func (p *GraceProvider) BeginWindow(_ context.Context, windowID string) error {
+	if p.unavailReason != "" {
+		return p.unavail()
+	}
+	w, err := p.sumWatts()
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.windows[windowID] = graceWindow{start: time.Now(), startWatts: w}
+	p.mu.Unlock()
+	return nil
+}
+
+// EndWindow integrates power over the elapsed window (trapezoidal) and returns joules.
+func (p *GraceProvider) EndWindow(_ context.Context, windowID string) (float64, error) {
+	if p.unavailReason != "" {
+		return 0, p.unavail()
+	}
+	p.mu.Lock()
+	begin, ok := p.windows[windowID]
+	delete(p.windows, windowID)
+	p.mu.Unlock()
+	if !ok {
+		return 0, fmt.Errorf("grace-hwmon window %q not found", windowID)
+	}
+	endWatts, err := p.sumWatts()
+	if err != nil {
+		return 0, err
+	}
+	elapsed := time.Since(begin.start).Seconds()
+	meanWatts := (begin.startWatts + endWatts) / 2
+	return meanWatts * elapsed, nil
+}
+
+// IdlePower returns the current summed rail power in watts.
+func (p *GraceProvider) IdlePower(_ context.Context) (float64, error) {
+	if p.unavailReason != "" {
+		return 0, p.unavail()
+	}
+	return p.sumWatts()
+}
+
+// Domains enumerates the selected power rails.
+func (p *GraceProvider) Domains(_ context.Context) ([]provider.Device, error) {
+	if p.unavailReason != "" {
+		return nil, p.unavail()
+	}
+	devs := make([]provider.Device, 0, len(p.rails))
+	for _, r := range p.rails {
+		devs = append(devs, provider.Device{ID: r.label, Name: r.label, Type: "cpu"})
+	}
+	return devs, nil
+}
+
+// Available reports whether matching Grace power rails were found at construction.
+func (p *GraceProvider) Available(_ context.Context) bool { return p.unavailReason == "" }
+
+// Name returns "grace-hwmon".
+func (p *GraceProvider) Name() string { return "grace-hwmon" }
+
+func readTrim(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func readUint(path string) (uint64, error) {
+	s, err := readTrim(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(s, 10, 64)
+}

--- a/internal/provider/hostenergy/gracehwmon/gracehwmon_stub.go
+++ b/internal/provider/hostenergy/gracehwmon/gracehwmon_stub.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+// This stub stands in for the Grace hwmon host-energy provider on non-Linux
+// builds. The real provider (gracehwmon.go) reads the Linux hwmon sysfs interface
+// and is build-tagged linux. Without it the package still registers "grace-hwmon"
+// so the name is recognised, but selecting it returns a clear error instead of
+// failing the build on non-Linux hosts.
+package gracehwmon
+
+import (
+	"fmt"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+func init() {
+	provider.RegisterHostEnergy("grace-hwmon", func(map[string]string) (provider.HostEnergyProvider, error) {
+		return nil, fmt.Errorf("grace-hwmon host energy provider is only available on linux")
+	})
+}

--- a/internal/provider/hostenergy/gracehwmon/gracehwmon_test.go
+++ b/internal/provider/hostenergy/gracehwmon/gracehwmon_test.go
@@ -1,0 +1,72 @@
+//go:build linux
+
+package gracehwmon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// writeRail creates <base>/<hwmon>/power<N>_{oem_info,average}.
+func writeRail(t *testing.T, base, hwmon string, n int, label string, avgUW uint64) {
+	t.Helper()
+	d := filepath.Join(base, hwmon)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oem := filepath.Join(d, "power"+strconv.Itoa(n)+"_oem_info")
+	avg := filepath.Join(d, "power"+strconv.Itoa(n)+"_average")
+	if err := os.WriteFile(oem, []byte(label), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(avg, []byte(strconv.FormatUint(avgUW, 10)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDiscoverSelectsMatchingRails(t *testing.T) {
+	base := t.TempDir()
+	// Two CPU rails (both sockets) plus a non-matching module rail.
+	writeRail(t, base, "hwmon0", 1, "CPU Power Socket 0", 40_000_000) // 40 W
+	writeRail(t, base, "hwmon0", 2, "CPU Power Socket 1", 35_000_000) // 35 W
+	writeRail(t, base, "hwmon0", 3, "Module Power Socket 0", 90_000_000)
+
+	p := newGrace(base, defaultRailMatch)
+	if !p.Available(context.Background()) {
+		t.Fatalf("expected available, got: %s", p.unavailReason)
+	}
+	domains, err := p.Domains(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(domains) != 2 {
+		t.Fatalf("want 2 CPU rails, got %d: %+v", len(domains), domains)
+	}
+	// IdlePower sums the two CPU rails: 40 + 35 = 75 W. Module rail excluded.
+	w, err := p.IdlePower(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w < 74.999 || w > 75.001 {
+		t.Fatalf("IdlePower = %v W, want 75", w)
+	}
+}
+
+func TestUnavailableWhenNoRails(t *testing.T) {
+	p := newGrace(t.TempDir(), defaultRailMatch)
+	if p.Available(context.Background()) {
+		t.Fatal("expected unavailable with no matching rails")
+	}
+	if err := p.BeginWindow(context.Background(), "w"); !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("BeginWindow err = %v, want ErrHostEnergyUnavailable", err)
+	}
+	if _, err := p.EndWindow(context.Background(), "w"); !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("EndWindow err = %v, want ErrHostEnergyUnavailable", err)
+	}
+}

--- a/internal/provider/hostenergy/gracespark/gracespark.go
+++ b/internal/provider/hostenergy/gracespark/gracespark.go
@@ -1,0 +1,367 @@
+//go:build linux
+
+// Package gracespark provides an EXPERIMENTAL HostEnergyProvider for the NVIDIA
+// GB10 / DGX Spark, reading the cumulative host-energy accumulator exposed by the
+// community out-of-tree kernel driver antheas/spark_hwmon.
+//
+// NVIDIA exposes no CPU/host power telemetry on Spark and has stated it has no
+// plans to (nvidia-smi reports GPU power only). The spark_hwmon driver reads the
+// System Power Budget Manager (SPBM) shared memory — updated by the MediaTek SSPM
+// firmware — and presents it through STANDARD hwmon sysfs: cumulative energy
+// counters, live power, and per-rail channels. Because it is ordinary hwmon, this
+// provider reads it the same way any other hwmon energy source would be read;
+// Aitra never touches SPBM, ACPI, or the MediaTek interface directly.
+//
+// This provider is deliberately a distinct provider from grace-hwmon (the 72-core
+// Superchip): the sysfs surface and the operational caveats differ. It is OFF by
+// default and must be selected explicitly, because the driver it reads is:
+//   - out-of-tree, DKMS-built, requiring MOK signing under Secure Boot;
+//   - self-described by its author as "vibe coded", with an SPBM ABI still in flux;
+//   - dependent on current firmware — older BIOS reports wrong CPU-channel values,
+//     which this provider cannot detect (the operator must update via fwupd).
+//
+// Aitra does not install, sign, version-check, or otherwise manage the driver.
+// That is the operator's responsibility. Aitra reads it if present and correct and
+// reports Available()==false otherwise. Readings taken through this path carry the
+// metric label provider="grace-spark-hwmon" (from Name()) so an operator can
+// segregate experimental-path data from the supported rapl / grace-hwmon paths.
+//
+// Energy source: the CUMULATIVE energy counter (energyN_input), differenced across
+// a window — the same pattern as NVML and RAPL. The instantaneous power channel is
+// deliberately NOT integrated: the firmware runs a ~100 ms PID control loop that
+// makes instantaneous power oscillate, whereas the accumulator already integrates
+// correctly in firmware and is the accurate source for a window average.
+//
+// The "never zero" contract of this subsystem is preserved exactly (see
+// provider.ErrHostEnergyUnavailable). hwmon has a specific hazard — a non-numeric
+// sysfs read is easily mistaken for 0 — so an unparseable read, a driver-absent
+// tree, or a counter that goes backwards within a window all become "unavailable",
+// never a zero, a negative, or a wrapped-large value.
+package gracespark
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+const (
+	providerName    = "grace-spark-hwmon"
+	defaultBasePath = "/sys/class/hwmon"
+
+	// defaultNameMatch is matched (case-insensitive substring) against each
+	// hwmon device's "name" file to locate the chip spark_hwmon registers. The
+	// exact string is not yet confirmed on hardware; it is configurable via the
+	// "name" config key precisely so it can be corrected without a code change.
+	defaultNameMatch = "spark"
+
+	// defaultRailInclude / defaultRailExclude select which energy rails constitute
+	// HOST energy. We sum the top-level package rail plus a DRAM-equivalent rail if
+	// one is exposed separately, and exclude per-core subsets (CPU performance /
+	// efficiency cores) which are already contained in the package rail — including
+	// them would double-count, exactly as core/uncore are excluded in RAPL.
+	defaultRailInclude = "package,dram,mem"
+	defaultRailExclude = "core"
+
+	// defaultEnergyUnit governs the divisor from the raw counter to joules. The
+	// spark_hwmon accumulator is documented in millijoules; standard hwmon energy
+	// is microjoules. Because the ABI is in flux this is configurable ("mj" | "uj")
+	// so an operator can correct the scale on hardware without a rebuild.
+	defaultEnergyUnit = "mj"
+)
+
+func init() {
+	provider.RegisterHostEnergy(providerName, func(config map[string]string) (provider.HostEnergyProvider, error) {
+		return newSpark(sparkConfig{
+			base:       orDefault(config["path"], defaultBasePath),
+			nameMatch:  orDefault(config["name"], defaultNameMatch),
+			include:    splitTokens(orDefault(config["rails"], defaultRailInclude)),
+			exclude:    splitTokens(orDefault(config["exclude"], defaultRailExclude)),
+			energyUnit: orDefault(config["energy_unit"], defaultEnergyUnit),
+		}), nil
+	})
+}
+
+type sparkConfig struct {
+	base       string
+	nameMatch  string
+	include    []string
+	exclude    []string
+	energyUnit string
+}
+
+// sparkRail is one selected hwmon cumulative-energy rail.
+type sparkRail struct {
+	label      string // from energyN_label, e.g. "package"
+	energyPath string // <hwmon>/energyN_input — the cumulative counter
+}
+
+// SparkProvider implements provider.HostEnergyProvider over the spark_hwmon
+// energy accumulators.
+type SparkProvider struct {
+	rails []sparkRail
+	// toJoules divides the raw counter unit to joules (1e3 for mJ, 1e6 for µJ).
+	toJoules float64
+	// unavailReason is non-empty when the node has no usable spark_hwmon telemetry;
+	// every read then returns ErrHostEnergyUnavailable wrapped with this reason.
+	unavailReason string
+
+	mu      sync.Mutex
+	windows map[string]map[string]uint64 // windowID -> label -> start counter
+}
+
+func newSpark(cfg sparkConfig) *SparkProvider {
+	div := 1e3 // millijoules
+	if strings.EqualFold(cfg.energyUnit, "uj") {
+		div = 1e6 // microjoules
+	}
+	rails, reason := discover(cfg)
+	return &SparkProvider{
+		rails:         rails,
+		toJoules:      div,
+		unavailReason: reason,
+		windows:       make(map[string]map[string]uint64),
+	}
+}
+
+// discover walks the hwmon tree for a device whose "name" matches the spark_hwmon
+// chip, then selects its cumulative-energy rails by energyN_label. It returns a
+// non-empty reason when no usable rail exists — the common case being a box where
+// the operator has not installed the driver.
+func discover(cfg sparkConfig) ([]sparkRail, string) {
+	hwmons, err := filepath.Glob(filepath.Join(cfg.base, "hwmon*"))
+	if err != nil || len(hwmons) == 0 {
+		return nil, fmt.Sprintf("no hwmon devices under %s (spark_hwmon driver not loaded)", cfg.base)
+	}
+
+	nameMatch := strings.ToLower(cfg.nameMatch)
+	chipFound := false
+	var rails []sparkRail
+	for _, h := range hwmons {
+		name, err := readTrim(filepath.Join(h, "name"))
+		if err != nil || !strings.Contains(strings.ToLower(name), nameMatch) {
+			continue
+		}
+		chipFound = true
+		// Enumerate energyN_label; never assume channel ordering.
+		labels, _ := filepath.Glob(filepath.Join(h, "energy*_label"))
+		for _, lf := range labels {
+			label, err := readTrim(lf)
+			if err != nil || !selectRail(label, cfg.include, cfg.exclude) {
+				continue
+			}
+			// energy<N>_label -> energy<N>_input (the cumulative counter).
+			energyPath := strings.TrimSuffix(lf, "_label") + "_input"
+			// Require a clean, parseable read now so a malformed rail is dropped at
+			// discovery rather than surfacing as a bad reading later.
+			if _, err := readUint(energyPath); err != nil {
+				continue
+			}
+			rails = append(rails, sparkRail{label: label, energyPath: energyPath})
+		}
+	}
+
+	if !chipFound {
+		return nil, fmt.Sprintf("spark_hwmon driver not loaded (no hwmon chip name matching %q under %s)", cfg.nameMatch, cfg.base)
+	}
+	if len(rails) == 0 {
+		return nil, fmt.Sprintf("spark_hwmon chip present but no cumulative-energy rail matching %v (excluding %v) under %s — firmware/driver flux?",
+			cfg.include, cfg.exclude, cfg.base)
+	}
+	return rails, ""
+}
+
+// selectRail reports whether a rail label is a host-energy rail: it must match an
+// include token and none of the exclude tokens (case-insensitive substrings).
+func selectRail(label string, include, exclude []string) bool {
+	l := strings.ToLower(label)
+	for _, ex := range exclude {
+		if ex != "" && strings.Contains(l, ex) {
+			return false
+		}
+	}
+	for _, in := range include {
+		if in != "" && strings.Contains(l, in) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *SparkProvider) unavail() error {
+	return fmt.Errorf("%w: %s", provider.ErrHostEnergyUnavailable, p.unavailReason)
+}
+
+// snapshot reads every selected rail's cumulative counter. A read that does not
+// parse as a number is an error (never silently 0), guarding the hwmon
+// "non-number reads as zero" hazard.
+func (p *SparkProvider) snapshot() (map[string]uint64, error) {
+	m := make(map[string]uint64, len(p.rails))
+	for _, r := range p.rails {
+		v, err := readUint(r.energyPath)
+		if err != nil {
+			return nil, fmt.Errorf("grace-spark-hwmon read %s: %w", r.energyPath, err)
+		}
+		m[r.label] = v
+	}
+	return m, nil
+}
+
+// BeginWindow snapshots every rail's cumulative energy counter.
+func (p *SparkProvider) BeginWindow(_ context.Context, windowID string) error {
+	if p.unavailReason != "" {
+		return p.unavail()
+	}
+	snap, err := p.snapshot()
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.windows[windowID] = snap
+	p.mu.Unlock()
+	return nil
+}
+
+// EndWindow differences each rail and returns the summed host energy in joules.
+//
+// hwmon exposes no documented maximum for an energy counter (unlike RAPL's
+// max_energy_range_uj), so the counter width at which it wraps is unknown until
+// confirmed on hardware. A counter that goes BACKWARDS within a window is
+// therefore treated as ErrHostEnergyUnavailable for that window — never emitted as
+// a negative or a wrapped-large value. Omitting one window is the safe failure;
+// emitting a garbage number is exactly what this subsystem exists to prevent.
+func (p *SparkProvider) EndWindow(_ context.Context, windowID string) (float64, error) {
+	if p.unavailReason != "" {
+		return 0, p.unavail()
+	}
+	p.mu.Lock()
+	start, ok := p.windows[windowID]
+	delete(p.windows, windowID)
+	p.mu.Unlock()
+	if !ok {
+		return 0, fmt.Errorf("grace-spark-hwmon window %q not found", windowID)
+	}
+
+	end, err := p.snapshot()
+	if err != nil {
+		return 0, err
+	}
+
+	var totalRaw uint64
+	for _, r := range p.rails {
+		s, ok := start[r.label]
+		if !ok {
+			continue
+		}
+		e := end[r.label]
+		if e < s {
+			// Counter decreased: possible wrap at an unconfirmed width, or firmware
+			// flux. Omit this window rather than guess.
+			return 0, fmt.Errorf("%w: rail %q counter decreased within window (%d -> %d) — "+
+				"possible wrap at unconfirmed width; window omitted", provider.ErrHostEnergyUnavailable, r.label, s, e)
+		}
+		totalRaw += e - s
+	}
+	// Convert the raw counter unit to joules at the boundary, not before.
+	return float64(totalRaw) / p.toJoules, nil
+}
+
+// IdlePower samples the accumulator over a short dwell and returns average watts.
+// It differences the same cumulative counter used for windows rather than reading
+// the oscillating instantaneous power channel. A decrease during the dwell is
+// reported as unavailable, never as a zero or negative power.
+func (p *SparkProvider) IdlePower(ctx context.Context) (float64, error) {
+	if p.unavailReason != "" {
+		return 0, p.unavail()
+	}
+	const dwell = 200 * time.Millisecond
+	first, err := p.snapshot()
+	if err != nil {
+		return 0, err
+	}
+	select {
+	case <-time.After(dwell):
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+	second, err := p.snapshot()
+	if err != nil {
+		return 0, err
+	}
+	var totalRaw uint64
+	for _, r := range p.rails {
+		s, e := first[r.label], second[r.label]
+		if e < s {
+			return 0, fmt.Errorf("%w: rail %q counter decreased during idle sample", provider.ErrHostEnergyUnavailable, r.label)
+		}
+		totalRaw += e - s
+	}
+	joules := float64(totalRaw) / p.toJoules
+	return joules / dwell.Seconds(), nil
+}
+
+// Domains enumerates the selected cumulative-energy rails.
+func (p *SparkProvider) Domains(_ context.Context) ([]provider.Device, error) {
+	if p.unavailReason != "" {
+		return nil, p.unavail()
+	}
+	devs := make([]provider.Device, 0, len(p.rails))
+	for _, r := range p.rails {
+		typ := "cpu"
+		ll := strings.ToLower(r.label)
+		if strings.Contains(ll, "dram") || strings.Contains(ll, "mem") {
+			typ = "dram"
+		}
+		devs = append(devs, provider.Device{ID: r.label, Name: "spark " + r.label, Type: typ})
+	}
+	return devs, nil
+}
+
+// Available reports whether usable spark_hwmon energy rails were found at
+// construction. False on a box without the (opt-in) community driver installed.
+func (p *SparkProvider) Available(_ context.Context) bool { return p.unavailReason == "" }
+
+// Name returns "grace-spark-hwmon" — carried as the provider metric label so
+// experimental-path readings are distinguishable from supported providers.
+func (p *SparkProvider) Name() string { return providerName }
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+func splitTokens(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.ToLower(strings.TrimSpace(p)); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func readTrim(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func readUint(path string) (uint64, error) {
+	s, err := readTrim(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(s, 10, 64)
+}

--- a/internal/provider/hostenergy/gracespark/gracespark_stub.go
+++ b/internal/provider/hostenergy/gracespark/gracespark_stub.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+// This stub stands in for the experimental grace-spark-hwmon host-energy provider
+// on non-Linux builds. The real provider (gracespark.go) reads the Linux hwmon
+// sysfs interface exposed by the community antheas/spark_hwmon driver and is
+// build-tagged linux. Without it the package still registers "grace-spark-hwmon"
+// so the name is recognised, but selecting it returns a clear error instead of
+// failing the build on non-Linux hosts.
+package gracespark
+
+import (
+	"fmt"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+func init() {
+	provider.RegisterHostEnergy("grace-spark-hwmon", func(map[string]string) (provider.HostEnergyProvider, error) {
+		return nil, fmt.Errorf("grace-spark-hwmon host energy provider is only available on linux")
+	})
+}

--- a/internal/provider/hostenergy/gracespark/gracespark_test.go
+++ b/internal/provider/hostenergy/gracespark/gracespark_test.go
@@ -1,0 +1,213 @@
+//go:build linux
+
+package gracespark
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// writeChipName sets <base>/<hwmon>/name.
+func writeChipName(t *testing.T, base, hwmon, name string) {
+	t.Helper()
+	d := filepath.Join(base, hwmon)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "name"), []byte(name), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeEnergyRail creates <base>/<hwmon>/energy<N>_{label,input}.
+func writeEnergyRail(t *testing.T, base, hwmon string, n int, label string, counter uint64) {
+	t.Helper()
+	d := filepath.Join(base, hwmon)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lbl := filepath.Join(d, "energy"+strconv.Itoa(n)+"_label")
+	inp := filepath.Join(d, "energy"+strconv.Itoa(n)+"_input")
+	if err := os.WriteFile(lbl, []byte(label), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(inp, []byte(strconv.FormatUint(counter, 10)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setCounter overwrites an existing energy<N>_input to simulate the counter
+// advancing (or decreasing) between snapshots.
+func setCounter(t *testing.T, base, hwmon string, n int, counter uint64) {
+	t.Helper()
+	inp := filepath.Join(base, hwmon, "energy"+strconv.Itoa(n)+"_input")
+	if err := os.WriteFile(inp, []byte(strconv.FormatUint(counter, 10)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestSpark(base string) *SparkProvider {
+	return newSpark(sparkConfig{
+		base:       base,
+		nameMatch:  defaultNameMatch,
+		include:    splitTokens(defaultRailInclude),
+		exclude:    splitTokens(defaultRailExclude),
+		energyUnit: defaultEnergyUnit, // millijoules
+	})
+}
+
+// TestWindowDeltaSumsRailsInJoules: the window delta equals the summed rail energy
+// converted from millijoules to joules, and per-core subsets are excluded so the
+// package rail is not double-counted.
+func TestWindowDeltaSumsRailsInJoules(t *testing.T) {
+	base := t.TempDir()
+	writeChipName(t, base, "hwmon3", "spark")
+	// package + dram are host energy; the perf/eff core rails are subsets of
+	// package and must be excluded (they contain "core").
+	writeEnergyRail(t, base, "hwmon3", 0, "package", 1_000_000)         // 1000 J start
+	writeEnergyRail(t, base, "hwmon3", 1, "dram", 200_000)              // 200 J start
+	writeEnergyRail(t, base, "hwmon3", 2, "CPU Performance Cores", 999) // excluded
+	writeEnergyRail(t, base, "hwmon3", 3, "CPU Efficiency Cores", 999)  // excluded
+
+	p := newTestSpark(base)
+	if !p.Available(context.Background()) {
+		t.Fatalf("expected available, got: %s", p.unavailReason)
+	}
+	domains, err := p.Domains(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(domains) != 2 {
+		t.Fatalf("want 2 host rails (package, dram), got %d: %+v", len(domains), domains)
+	}
+
+	ctx := context.Background()
+	if err := p.BeginWindow(ctx, "w1"); err != nil {
+		t.Fatal(err)
+	}
+	// Advance: package +50_000 mJ, dram +10_000 mJ = 60_000 mJ = 60 J.
+	setCounter(t, base, "hwmon3", 0, 1_050_000)
+	setCounter(t, base, "hwmon3", 1, 210_000)
+	// A core rail also advancing must not affect the sum.
+	setCounter(t, base, "hwmon3", 2, 5_000)
+
+	j, err := p.EndWindow(ctx, "w1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j < 59.999 || j > 60.001 {
+		t.Fatalf("EndWindow = %v J, want 60", j)
+	}
+}
+
+// TestDriverAbsentIsUnavailable: no hwmon chip matching the spark name means the
+// provider is unavailable and every read returns ErrHostEnergyUnavailable — never
+// a zero. This is the common case on a box without the community driver.
+func TestDriverAbsentIsUnavailable(t *testing.T) {
+	base := t.TempDir()
+	// A different chip present, but nothing named "spark".
+	writeChipName(t, base, "hwmon0", "coretemp")
+	writeEnergyRail(t, base, "hwmon0", 0, "package", 500_000)
+
+	p := newTestSpark(base)
+	if p.Available(context.Background()) {
+		t.Fatal("expected unavailable when no spark chip present")
+	}
+	if err := p.BeginWindow(context.Background(), "w"); !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("BeginWindow err = %v, want ErrHostEnergyUnavailable", err)
+	}
+	if j, err := p.EndWindow(context.Background(), "w"); !errors.Is(err, provider.ErrHostEnergyUnavailable) || j != 0 {
+		t.Fatalf("EndWindow = (%v, %v), want (0, ErrHostEnergyUnavailable)", j, err)
+	}
+}
+
+// TestMalformedReadNeverZero: a malformed (non-numeric / empty) counter must not
+// be read as 0. At discovery it drops the rail; if it were the only rail the
+// provider is unavailable rather than reporting a zero reading.
+func TestMalformedReadNeverZero(t *testing.T) {
+	base := t.TempDir()
+	writeChipName(t, base, "hwmon3", "spark")
+	// Non-numeric content — the exact hwmon "non-number is 0" hazard.
+	d := filepath.Join(base, "hwmon3")
+	if err := os.WriteFile(filepath.Join(d, "energy0_label"), []byte("package"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "energy0_input"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newTestSpark(base)
+	if p.Available(context.Background()) {
+		t.Fatal("expected unavailable when the only rail is unreadable — must not report a zero rail")
+	}
+	if _, err := p.EndWindow(context.Background(), "w"); !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("EndWindow err = %v, want ErrHostEnergyUnavailable", err)
+	}
+}
+
+// TestCounterDecreaseIsUnavailable: a counter that goes backwards within a window
+// (possible wrap at an unconfirmed width) must yield ErrHostEnergyUnavailable for
+// that window — never a negative and never a wrapped-large value.
+func TestCounterDecreaseIsUnavailable(t *testing.T) {
+	base := t.TempDir()
+	writeChipName(t, base, "hwmon3", "spark")
+	writeEnergyRail(t, base, "hwmon3", 0, "package", 1_000_000)
+
+	p := newTestSpark(base)
+	ctx := context.Background()
+	if err := p.BeginWindow(ctx, "w"); err != nil {
+		t.Fatal(err)
+	}
+	setCounter(t, base, "hwmon3", 0, 900_000) // decreased
+
+	j, err := p.EndWindow(ctx, "w")
+	if !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("EndWindow err = %v, want ErrHostEnergyUnavailable on decrease", err)
+	}
+	if j != 0 {
+		t.Fatalf("EndWindow joules = %v, want 0 (never negative, never wrapped-large)", j)
+	}
+}
+
+// TestProviderLabel: the provider identifies as grace-spark-hwmon so experimental
+// -path readings carry a distinct provider metric label.
+func TestProviderLabel(t *testing.T) {
+	p := newTestSpark(t.TempDir())
+	if got := p.Name(); got != "grace-spark-hwmon" {
+		t.Fatalf("Name() = %q, want grace-spark-hwmon", got)
+	}
+}
+
+// TestMicrojouleUnitConfig: energy_unit=uj switches the divisor to 1e6.
+func TestMicrojouleUnitConfig(t *testing.T) {
+	base := t.TempDir()
+	writeChipName(t, base, "hwmon3", "spark")
+	writeEnergyRail(t, base, "hwmon3", 0, "package", 0)
+
+	p := newSpark(sparkConfig{
+		base:       base,
+		nameMatch:  defaultNameMatch,
+		include:    splitTokens(defaultRailInclude),
+		exclude:    splitTokens(defaultRailExclude),
+		energyUnit: "uj",
+	})
+	ctx := context.Background()
+	if err := p.BeginWindow(ctx, "w"); err != nil {
+		t.Fatal(err)
+	}
+	setCounter(t, base, "hwmon3", 0, 6_000_000) // +6e6 µJ = 6 J
+
+	j, err := p.EndWindow(ctx, "w")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j < 5.999 || j > 6.001 {
+		t.Fatalf("EndWindow = %v J, want 6 (µJ unit)", j)
+	}
+}

--- a/internal/provider/hostenergy/rapl/rapl.go
+++ b/internal/provider/hostenergy/rapl/rapl.go
@@ -1,0 +1,279 @@
+//go:build linux
+
+// Package rapl provides a HostEnergyProvider that reads host (CPU package + DRAM)
+// energy from the Linux powercap RAPL interface at /sys/class/powercap. It is
+// pure Go — no cgo, no sidecar, no new dependency — and reads a monotonic
+// microjoule counter that it differences across a window, exactly like the NVML
+// accelerator provider differences its energy accumulator.
+//
+// Domain selection: it sums the "package-N" domains and their "dram" subdomains.
+// It deliberately excludes "core"/"uncore" (which are subsets of package and
+// would double-count) and "psys" (a platform-wide superset that overlaps
+// package). Domains are identified by reading each directory's "name" file, never
+// by assuming ordering.
+//
+// On hardware with no RAPL interface, or where energy_uj exists but is unreadable
+// (it is 0400 root on many distributions following CVE-2020-8694), the provider
+// reports Available()==false and every read returns provider.ErrHostEnergyUnavailable
+// with a distinct reason. It never returns a zero reading and never crashes.
+package rapl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+const defaultBasePath = "/sys/class/powercap"
+
+func init() {
+	provider.RegisterHostEnergy("rapl", func(config map[string]string) (provider.HostEnergyProvider, error) {
+		base := config["path"]
+		if base == "" {
+			base = defaultBasePath
+		}
+		return newRAPL(base), nil
+	})
+}
+
+// raplDomain is a single measurable RAPL domain (a package or a dram subdomain).
+type raplDomain struct {
+	name       string // e.g. "package-0", "dram"
+	energyPath string // <dir>/energy_uj
+	maxRangeUJ uint64 // <dir>/max_energy_range_uj — the value the counter wraps at
+}
+
+// RAPLProvider implements provider.HostEnergyProvider over /sys/class/powercap.
+type RAPLProvider struct {
+	basePath string
+
+	// domains and unavailReason are resolved once at construction. If
+	// unavailReason != "" the node has no usable RAPL telemetry and every read
+	// returns ErrHostEnergyUnavailable wrapped with that reason.
+	domains       []raplDomain
+	unavailReason string
+
+	mu      sync.Mutex
+	windows map[string]map[string]uint64 // windowID -> domainName -> start microjoules
+}
+
+func newRAPL(base string) *RAPLProvider {
+	domains, reason := discover(base)
+	return &RAPLProvider{
+		basePath:      base,
+		domains:       domains,
+		unavailReason: reason,
+		windows:       make(map[string]map[string]uint64),
+	}
+}
+
+// discover walks the powercap tree and returns the package + dram domains whose
+// energy_uj is readable, plus a reason string that is non-empty when no usable
+// domain exists (absent interface, or present-but-unreadable).
+func discover(base string) ([]raplDomain, string) {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Sprintf("no RAPL interface at %s (powercap/intel-rapl not present on this node)", base)
+		}
+		return nil, fmt.Sprintf("cannot read %s: %v", base, err)
+	}
+
+	var domains []raplDomain
+	permissionDenied := false
+	for _, e := range entries {
+		name := e.Name()
+		// Match intel-rapl:0, intel-rapl:0:1, etc. Exclude intel-rapl-mmio:*.
+		if !strings.HasPrefix(name, "intel-rapl:") {
+			continue
+		}
+		dir := filepath.Join(base, name)
+		domainName, err := readTrim(filepath.Join(dir, "name"))
+		if err != nil {
+			continue
+		}
+		// package-N (top-level socket) and dram (its subdomain) only. core/uncore
+		// are subsets of package; psys overlaps it — including either double-counts.
+		if !strings.HasPrefix(domainName, "package") && domainName != "dram" {
+			continue
+		}
+		energyPath := filepath.Join(dir, "energy_uj")
+		if _, err := readUint(energyPath); err != nil {
+			if errors.Is(err, os.ErrPermission) {
+				permissionDenied = true
+			}
+			continue
+		}
+		maxRange, _ := readUint(filepath.Join(dir, "max_energy_range_uj"))
+		domains = append(domains, raplDomain{name: domainName, energyPath: energyPath, maxRangeUJ: maxRange})
+	}
+
+	if len(domains) == 0 {
+		if permissionDenied {
+			return nil, fmt.Sprintf("RAPL energy_uj present under %s but unreadable (permission denied — "+
+				"energy_uj is 0400 root since CVE-2020-8694; run the agent as root or make the file group-readable)", base)
+		}
+		return nil, fmt.Sprintf("no readable package/dram RAPL domains under %s", base)
+	}
+	return domains, ""
+}
+
+func (p *RAPLProvider) unavail() error {
+	return fmt.Errorf("%w: %s", provider.ErrHostEnergyUnavailable, p.unavailReason)
+}
+
+// BeginWindow snapshots every domain's raw microjoule counter.
+func (p *RAPLProvider) BeginWindow(_ context.Context, windowID string) error {
+	if p.unavailReason != "" {
+		return p.unavail()
+	}
+	snap := make(map[string]uint64, len(p.domains))
+	for _, d := range p.domains {
+		v, err := readUint(d.energyPath)
+		if err != nil {
+			return fmt.Errorf("rapl BeginWindow read %s: %w", d.energyPath, err)
+		}
+		snap[d.name] = v
+	}
+	p.mu.Lock()
+	p.windows[windowID] = snap
+	p.mu.Unlock()
+	return nil
+}
+
+// EndWindow differences each domain (handling counter wraparound) and returns the
+// summed host energy in joules.
+func (p *RAPLProvider) EndWindow(_ context.Context, windowID string) (float64, error) {
+	if p.unavailReason != "" {
+		return 0, p.unavail()
+	}
+	p.mu.Lock()
+	start, ok := p.windows[windowID]
+	delete(p.windows, windowID)
+	p.mu.Unlock()
+	if !ok {
+		return 0, fmt.Errorf("rapl window %q not found", windowID)
+	}
+
+	var totalUJ uint64
+	for _, d := range p.domains {
+		s, ok := start[d.name]
+		if !ok {
+			continue
+		}
+		e, err := readUint(d.energyPath)
+		if err != nil {
+			return 0, fmt.Errorf("rapl EndWindow read %s: %w", d.energyPath, err)
+		}
+		totalUJ += windowDelta(s, e, d.maxRangeUJ)
+	}
+	// Convert microjoules to joules at the boundary, not before.
+	return float64(totalUJ) / 1e6, nil
+}
+
+// windowDelta returns end-start, correcting for a single counter wrap. energy_uj
+// is a uint64 that resets to 0 after reaching max_energy_range_uj; at high power
+// the counter can wrap within a window. A naive end-start underflows to a huge
+// value on wrap — the most likely silent correctness bug in this provider.
+//
+// It assumes at most one wrap per window, which holds for the 10–30 s windows the
+// agent uses against the ~65 kJ–262 kJ ranges typical of package/dram counters.
+func windowDelta(start, end, maxRange uint64) uint64 {
+	if end >= start {
+		return end - start
+	}
+	// Wrapped. Recover only if we know the range the counter wraps at.
+	if maxRange > start {
+		return (maxRange - start) + end
+	}
+	// No usable range — cannot recover this window's delta. Drop it (0) rather
+	// than emit a garbage negative-turned-huge value.
+	return 0
+}
+
+// IdlePower samples the counters over a short dwell and returns average watts.
+// RAPL exposes an energy counter, not an instantaneous power reading, so power is
+// derived by differencing over a brief interval.
+func (p *RAPLProvider) IdlePower(ctx context.Context) (float64, error) {
+	if p.unavailReason != "" {
+		return 0, p.unavail()
+	}
+	const dwell = 200 * time.Millisecond
+	first, err := p.sample()
+	if err != nil {
+		return 0, err
+	}
+	select {
+	case <-time.After(dwell):
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+	second, err := p.sample()
+	if err != nil {
+		return 0, err
+	}
+	var totalUJ uint64
+	for _, d := range p.domains {
+		totalUJ += windowDelta(first[d.name], second[d.name], d.maxRangeUJ)
+	}
+	joules := float64(totalUJ) / 1e6
+	return joules / dwell.Seconds(), nil
+}
+
+func (p *RAPLProvider) sample() (map[string]uint64, error) {
+	m := make(map[string]uint64, len(p.domains))
+	for _, d := range p.domains {
+		v, err := readUint(d.energyPath)
+		if err != nil {
+			return nil, fmt.Errorf("rapl sample read %s: %w", d.energyPath, err)
+		}
+		m[d.name] = v
+	}
+	return m, nil
+}
+
+// Domains enumerates the measurable host energy domains.
+func (p *RAPLProvider) Domains(_ context.Context) ([]provider.Device, error) {
+	if p.unavailReason != "" {
+		return nil, p.unavail()
+	}
+	devs := make([]provider.Device, 0, len(p.domains))
+	for _, d := range p.domains {
+		typ := "cpu"
+		if d.name == "dram" {
+			typ = "dram"
+		}
+		devs = append(devs, provider.Device{ID: d.name, Name: "RAPL " + d.name, Type: typ})
+	}
+	return devs, nil
+}
+
+// Available reports whether usable RAPL telemetry was found at construction.
+func (p *RAPLProvider) Available(_ context.Context) bool { return p.unavailReason == "" }
+
+// Name returns "rapl".
+func (p *RAPLProvider) Name() string { return "rapl" }
+
+func readTrim(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func readUint(path string) (uint64, error) {
+	s, err := readTrim(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(s, 10, 64)
+}

--- a/internal/provider/hostenergy/rapl/rapl_stub.go
+++ b/internal/provider/hostenergy/rapl/rapl_stub.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+// This stub stands in for the RAPL host-energy provider on non-Linux builds.
+// RAPL is a Linux powercap sysfs interface (/sys/class/powercap), so the real
+// provider (rapl.go) is build-tagged linux. Without it the package still
+// registers "rapl" so the name is recognised, but selecting it returns a clear
+// error instead of failing the build on non-Linux hosts.
+package rapl
+
+import (
+	"fmt"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+func init() {
+	provider.RegisterHostEnergy("rapl", func(map[string]string) (provider.HostEnergyProvider, error) {
+		return nil, fmt.Errorf("rapl host energy provider is only available on linux")
+	})
+}

--- a/internal/provider/hostenergy/rapl/rapl_test.go
+++ b/internal/provider/hostenergy/rapl/rapl_test.go
@@ -1,0 +1,180 @@
+//go:build linux
+
+package rapl
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+// writeDomain creates <base>/<dir>/{name,energy_uj,max_energy_range_uj}.
+func writeDomain(t *testing.T, base, dir, name string, energyUJ, maxRange uint64) string {
+	t.Helper()
+	d := filepath.Join(base, dir)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(f, v string) {
+		if err := os.WriteFile(filepath.Join(d, f), []byte(v), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("name", name)
+	write("energy_uj", itoa(energyUJ))
+	write("max_energy_range_uj", itoa(maxRange))
+	return filepath.Join(d, "energy_uj")
+}
+
+func itoa(v uint64) string { return strconv.FormatUint(v, 10) }
+
+// fixture builds a two-domain tree: package-0 and its dram subdomain, plus a
+// core subdomain that MUST be ignored (it is a subset of package).
+func fixture(t *testing.T) (base, pkgEnergy, dramEnergy string) {
+	t.Helper()
+	base = t.TempDir()
+	pkgEnergy = writeDomain(t, base, "intel-rapl:0", "package-0", 1_000_000, 262_143_328_850)
+	dramEnergy = writeDomain(t, base, "intel-rapl:0:0", "dram", 500_000, 65_712_999_613)
+	// core is a subset of package — enumerating it would double-count.
+	writeDomain(t, base, "intel-rapl:0:1", "core", 400_000, 262_143_328_850)
+	return
+}
+
+func setEnergy(t *testing.T, path string, v uint64) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(itoa(v)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDiscoverSelectsPackageAndDramOnly(t *testing.T) {
+	base, _, _ := fixture(t)
+	p := newRAPL(base)
+	if !p.Available(context.Background()) {
+		t.Fatalf("expected available, got unavailable: %s", p.unavailReason)
+	}
+	domains, err := p.Domains(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(domains) != 2 {
+		t.Fatalf("want 2 domains (package-0, dram), got %d: %+v", len(domains), domains)
+	}
+	names := map[string]bool{}
+	for _, d := range domains {
+		names[d.ID] = true
+	}
+	if !names["package-0"] || !names["dram"] {
+		t.Fatalf("missing expected domains: %+v", names)
+	}
+	if names["core"] {
+		t.Fatal("core domain must be excluded (subset of package)")
+	}
+}
+
+func TestEndWindowSumsPackagePlusDram(t *testing.T) {
+	base, pkg, dram := fixture(t)
+	p := newRAPL(base)
+	ctx := context.Background()
+	if err := p.BeginWindow(ctx, "w1"); err != nil {
+		t.Fatal(err)
+	}
+	// package advances 2_000_000 uJ, dram advances 300_000 uJ.
+	setEnergy(t, pkg, 3_000_000)
+	setEnergy(t, dram, 800_000)
+	j, err := p.EndWindow(ctx, "w1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// (2_000_000 + 300_000) uJ = 2.3 J
+	if got, want := j, 2.3; !approx(got, want) {
+		t.Fatalf("host joules = %v, want %v", got, want)
+	}
+}
+
+func TestWraparound(t *testing.T) {
+	base := t.TempDir()
+	const maxRange = 262_143_328_850
+	pkg := writeDomain(t, base, "intel-rapl:0", "package-0", maxRange-100_000, maxRange)
+	p := newRAPL(base)
+	ctx := context.Background()
+	if err := p.BeginWindow(ctx, "w"); err != nil {
+		t.Fatal(err)
+	}
+	// Counter wraps: it was 100_000 below max, advances 250_000 uJ, so it lands at
+	// 150_000 after wrapping through 0. A naive end-start would be a huge negative.
+	setEnergy(t, pkg, 150_000)
+	j, err := p.EndWindow(ctx, "w")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// True delta = 100_000 + 150_000 = 250_000 uJ = 0.25 J
+	if got, want := j, 0.25; !approx(got, want) {
+		t.Fatalf("wraparound host joules = %v, want %v", got, want)
+	}
+}
+
+func TestWindowDeltaUnit(t *testing.T) {
+	cases := []struct {
+		start, end, max, want uint64
+	}{
+		{100, 250, 1000, 150}, // no wrap
+		{900, 150, 1000, 250}, // wrap: (1000-900)+150
+		{900, 150, 0, 0},      // wrap with no range info -> drop
+		{0, 0, 1000, 0},       // idle
+		{500, 500, 1000, 0},   // no change
+	}
+	for _, c := range cases {
+		if got := windowDelta(c.start, c.end, c.max); got != c.want {
+			t.Errorf("windowDelta(%d,%d,%d)=%d want %d", c.start, c.end, c.max, got, c.want)
+		}
+	}
+}
+
+func TestUnavailableWhenPathAbsent(t *testing.T) {
+	p := newRAPL(filepath.Join(t.TempDir(), "does-not-exist"))
+	if p.Available(context.Background()) {
+		t.Fatal("expected unavailable for absent powercap path")
+	}
+	// Every read returns ErrHostEnergyUnavailable, never a zero reading.
+	if err := p.BeginWindow(context.Background(), "w"); !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("BeginWindow err = %v, want ErrHostEnergyUnavailable", err)
+	}
+	if _, err := p.EndWindow(context.Background(), "w"); !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("EndWindow err = %v, want ErrHostEnergyUnavailable", err)
+	}
+	if _, err := p.IdlePower(context.Background()); !errors.Is(err, provider.ErrHostEnergyUnavailable) {
+		t.Fatalf("IdlePower err = %v, want ErrHostEnergyUnavailable", err)
+	}
+}
+
+func TestUnavailableWhenEnergyUnreadable(t *testing.T) {
+	base := t.TempDir()
+	// A domain whose energy_uj is a directory, not a file — read fails, so the
+	// domain is unusable and the provider must report unavailable, not crash and
+	// not zero.
+	d := filepath.Join(base, "intel-rapl:0")
+	if err := os.MkdirAll(filepath.Join(d, "energy_uj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "name"), []byte("package-0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := newRAPL(base)
+	if p.Available(context.Background()) {
+		t.Fatal("expected unavailable when energy_uj is unreadable")
+	}
+}
+
+func approx(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < 1e-9
+}

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,18 +55,26 @@ CREATE TABLE IF NOT EXISTS aitra_measurements (
 	cv                 REAL    NOT NULL,
 	stable             INTEGER NOT NULL,
 	energy_provider    TEXT    NOT NULL,
-	inference_provider TEXT    NOT NULL
+	inference_provider TEXT    NOT NULL,
+	-- Nullable on purpose: NULL means host energy was not measured on this node,
+	-- which is distinct from a measured zero. Never store 0 for "unmeasured".
+	host_energy_joules REAL
 );
 CREATE INDEX IF NOT EXISTS idx_cluster_ns_ts
 	ON aitra_measurements (cluster, namespace, timestamp_ms);`
+
+// migrateAddHostEnergySQL adds host_energy_joules to databases created before
+// issue #82. "duplicate column name" is expected and ignored on new databases
+// (where the column is already in createTableSQL).
+const migrateAddHostEnergySQL = `ALTER TABLE aitra_measurements ADD COLUMN host_energy_joules REAL`
 
 const insertSQL = `
 INSERT INTO aitra_measurements (
 	timestamp_ms, cluster, node, namespace, workload, model, hardware, precision,
 	team, cost_centre, energy_joules, output_tokens, j_per_token,
 	calibration_tier, ref_j_per_token, attribution_method, cv, stable,
-	energy_provider, inference_provider
-) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+	energy_provider, inference_provider, host_energy_joules
+) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
 
 const chargebackSQL = `
 SELECT
@@ -104,6 +113,13 @@ func New(path string) (*Backend, error) {
 		return nil, fmt.Errorf("sqlite create table: %w", err)
 	}
 
+	// Add host_energy_joules to pre-#82 databases. Ignore the "duplicate column"
+	// error that a new database (already carrying the column) returns.
+	if _, err := db.Exec(migrateAddHostEnergySQL); err != nil && !strings.Contains(err.Error(), "duplicate column") {
+		db.Close()
+		return nil, fmt.Errorf("sqlite migrate host_energy_joules: %w", err)
+	}
+
 	stmt, err := db.Prepare(insertSQL)
 	if err != nil {
 		db.Close()
@@ -138,13 +154,19 @@ func (b *Backend) WriteBatch(ctx context.Context, rs []model.MeasurementRecord) 
 		if r.Stable {
 			stable = 1
 		}
+		// nil pointer -> SQL NULL (not measured); a value -> the measured joules.
+		// This is where "absent is not zero" is enforced at the storage boundary.
+		hostEnergy := sql.NullFloat64{}
+		if r.HostEnergyJoules != nil {
+			hostEnergy = sql.NullFloat64{Float64: *r.HostEnergyJoules, Valid: true}
+		}
 		if _, err := txStmt.ExecContext(ctx,
 			r.TimestampUnixMs, r.Cluster, r.Node, r.Namespace, r.Workload,
 			r.Model, r.Hardware, r.Precision, r.Team, r.CostCentre,
 			r.EnergyJoules, r.OutputTokens, r.JPerToken,
 			string(r.CalibrationTier), r.RefJPerToken,
 			string(r.AttributionMethod), r.CV, stable,
-			r.EnergyProvider, r.InferenceProvider,
+			r.EnergyProvider, r.InferenceProvider, hostEnergy,
 		); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("sqlite insert: %w", err)

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -104,6 +105,43 @@ func TestWriteAndQueryChargeback(t *testing.T) {
 	}
 	if prod.OutputTokens != 1000 {
 		t.Errorf("prod tokens: got %d, want 1000", prod.OutputTokens)
+	}
+}
+
+// TestHostEnergyRoundTripAbsentIsNotZero protects the central contract of issue
+// #82 at the storage boundary: a nil HostEnergyJoules must persist as SQL NULL
+// (not measured), never as 0. A record that did measure host energy persists the
+// value.
+func TestHostEnergyRoundTrip(t *testing.T) {
+	b := newTestBackend(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	hostJ := 42.5
+	records := []model.MeasurementRecord{
+		{TimestampUnixMs: now.UnixMilli(), Cluster: "c", Node: "measured", Namespace: "ns", HostEnergyJoules: &hostJ},
+		{TimestampUnixMs: now.UnixMilli(), Cluster: "c", Node: "unmeasured", Namespace: "ns", HostEnergyJoules: nil},
+	}
+	if err := b.WriteBatch(ctx, records); err != nil {
+		t.Fatalf("WriteBatch: %v", err)
+	}
+
+	read := func(node string) sql.NullFloat64 {
+		var v sql.NullFloat64
+		err := b.db.QueryRowContext(ctx,
+			`SELECT host_energy_joules FROM aitra_measurements WHERE node = ?`, node).Scan(&v)
+		if err != nil {
+			t.Fatalf("scan %s: %v", node, err)
+		}
+		return v
+	}
+
+	if got := read("measured"); !got.Valid || got.Float64 != hostJ {
+		t.Fatalf("measured node: got %+v, want valid %v", got, hostJ)
+	}
+	// The one that matters: unmeasured must be NULL, never 0.
+	if got := read("unmeasured"); got.Valid {
+		t.Fatalf("unmeasured node: got valid=%v value=%v, want SQL NULL (not measured)", got.Valid, got.Float64)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements host (non-accelerator) energy measurement for issue #82, plus the design addendum's experimental GB10 provider. `aitra_j_per_token` measures **GPU energy only**; this adds a `HostEnergyProvider` abstraction (mirroring `EnergyProvider`) that measures CPU package + DRAM (+ board) energy per window and derives whole-system efficiency:

- `aitra_system_j_per_token` = `(gpu + host) / tokens`
- `aitra_host_energy_fraction` = `host / (gpu + host)`
- `aitra_host_energy_joules_total`, `aitra_host_power_watts`

`aitra_j_per_token` keeps its GPU-only meaning (docstring updated).

### Central contract — absent is not zero
A node with no host telemetry **omits** every host metric rather than emitting `0`. A zero would understate whole-node efficiency and make an *unmeasured* node look **more efficient** than a measured one. Enforced end to end: `ErrHostEnergyUnavailable`, `optional` proto fields, a `*float64` record field, a nullable SQLite column, and presence-guarded metric writes.

## Providers

| Platform | Provider | Tier |
|---|---|---|
| x86 (Intel/AMD) | `rapl` | Supported — pure Go, sums `package`+`dram` from `/sys/class/powercap`, handles `energy_uj` wraparound, distinct unavailable reasons for absent vs unreadable (CVE-2020-8694) |
| Grace Superchip (72-core) | `grace-hwmon` | Supported — integrates `power1_average`, rail via `power1_oem_info` |
| **GB10 / DGX Spark** | **`grace-spark-hwmon`** | **Experimental, opt-in** — reads the community `antheas/spark_hwmon` accumulator via standard hwmon |
| GB10 / Spark, driver absent | `none` | Unavailable (never zero) |
| Default | `none` (`NoopHostEnergy`) | Supported |

### `grace-spark-hwmon` (the addendum — GB10 / DGX Spark)
NVIDIA exposes no CPU/host power telemetry on Spark and has no plans to. The community `antheas/spark_hwmon` driver surfaces the MediaTek SSPM firmware's energy accumulator through standard hwmon. This provider reads it **only if the operator has installed it** — Aitra never bundles, installs, signs, or version-checks the driver. Both spec contracts hold:

- **No hard dependency** — driver absent ⇒ `unavailable`.
- **Absent is not zero** — an unparseable read (hwmon's "non-number reads as 0" hazard), or a counter that goes backwards within a window (possible wrap at an unconfirmed width) ⇒ `unavailable`, never a zero/negative/wrapped-large value.

Reads the `energyN_input` accumulator and differences it (not the oscillating instantaneous power channel); sums `package`+`dram` by `energyN_label` while excluding per-core subsets to avoid double-counting; unit configurable (`mj` default / `uj`) since the SPBM ABI is in flux. Readings carry `provider="grace-spark-hwmon"` so experimental-path data is segregable in Prometheus from the supported `rapl` / `grace-hwmon` paths. Off by default; selected explicitly.

## Tests
- `rapl`: enumeration, package+dram sum, **wraparound at `max_energy_range_uj`**, unavailable/unreadable.
- `grace-hwmon`: rail selection + integration, unavailable.
- `grace-spark-hwmon`: delta→joules with core-subset exclusion, driver-absent, malformed-read-never-zero, counter-decrease→unavailable, provider label, `uj` unit.
- `aggregation`: system J/token present-path, and **absent-is-not-zero** (asserts metrics omitted, not zeroed).
- `sqlite`: `nil` HostEnergyJoules round-trips as `NULL`, not `0`.

`go build`, `go vet`, gofmt clean. Helm renders the `/sys/class/powercap` mount for `rapl` and `/sys/class/hwmon` for the hwmon providers; `helm lint` passes.

## Notes for reviewers
- This branch predates the base #82 commit landing on `main`, so the PR contains **both** the base host-energy implementation (`b9b9641`) and the GB10 addendum (`b4879d8`).
- The branch is currently behind `main` (grafana/opencost/chart-bump commits); a rebase will likely be needed before merge — `main` has since touched `Chart.yaml`, `values.yaml`, and `measurement-agent.yaml`.
- Pre-existing, unrelated: `TestLoopCVAccumulates` in `internal/aggregation` fails on the base commit (`CV = 0 ... want 0`) — its assertion logic looks off. Not introduced here; flagging for a separate fix.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
