### PR TITLE
feat(inference): add dedicated Ollama provider

### DIFF
--- a/cmd/measurement-agent/main.go
+++ b/cmd/measurement-agent/main.go
@@ -18,12 +18,13 @@ import (
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/dcgm"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/energy/zeus"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/genericprometheus"
+	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/ollama"
 	_ "github.com/aitra-ai/aitra-meter/internal/provider/inference/vllm"
 )
 
 func main() {
 	energyType := flag.String("energy-provider", "nvml", "Energy provider: nvml | amd | zeus | dcgm")
-	inferenceType := flag.String("inference-provider", "vllm", "Inference provider: vllm | generic-prometheus")
+	inferenceType := flag.String("inference-provider", "vllm", "Inference provider: vllm | ollama | generic-prometheus")
 	aggregatorAddr := flag.String("aggregator", "aitra-meter-aggregation:9091", "Aggregation service gRPC address")
 	nodeName := flag.String("node", "", "Kubernetes node name (defaults to NODE_NAME env var)")
 	windowSecs := flag.Int("window-seconds", 30, "Measurement window duration in seconds")

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -17,7 +17,7 @@
 | Generic Prometheus | `generic-prometheus` | TGI, SGLang, Ollama, Triton, any custom server | Configure metric names via `config` map. Works with any server exposing Prometheus metrics. |
 | TGI | `tgi` (community) | HuggingFace Text Generation Inference | Dedicated adapter with TGI-specific metric names pre-configured |
 | SGLang | `sglang` (community) | SGLang | Dedicated adapter |
-| Ollama | `ollama` (community) | Ollama | Dedicated adapter |
+| Ollama | `ollama` | Ollama | Built-in adapter. Reads token/request counters from Ollama's Prometheus `/metrics`, and the served model name from Ollama's native `/api/ps` |
 | Triton | `triton` (community) | NVIDIA Triton Inference Server | Dedicated adapter |
 
 ## Using `generic-prometheus` for TGI
@@ -47,6 +47,31 @@ measurementAgent:
       requests_running_metric: "sglang:num_running_reqs"
       model_name_label: "model_name"
 ```
+
+## Using the dedicated `ollama` provider
+
+Ollama has a built-in adapter. It reads token and request counters from Ollama's
+Prometheus `/metrics` endpoint and resolves the served model name from Ollama's
+native `/api/ps` endpoint (available on every Ollama build), so no
+`model_name_label` is needed:
+
+```yaml
+measurementAgent:
+  inferenceProvider:
+    type: ollama
+    config:
+      endpoint: "http://localhost:11434/metrics"   # Prometheus metrics (default)
+      api_base: "http://localhost:11434"            # native API for /api/ps (default)
+      # Overridable if your build/exporter uses different names:
+      # output_tokens_metric: "ollama_completion_tokens_total"
+      # requests_running_metric: "ollama_requests_active"
+```
+
+> **Note:** Token and request metrics require an Ollama build (or exporter
+> sidecar) that exposes a Prometheus `/metrics` endpoint. Ollama releases
+> without `/metrics` will error on `OutputTokens`; the model name from
+> `/api/ps` still works. For servers with different metric names, the
+> `generic-prometheus` provider below remains available.
 
 ## Using `generic-prometheus` for Ollama
 

--- a/helm/aitra-meter/values.yaml
+++ b/helm/aitra-meter/values.yaml
@@ -49,6 +49,12 @@ measurementAgent:
     type: vllm
     config:
       endpoint: "http://localhost:8000/metrics"
+  # ollama example (dedicated adapter; model name resolved via Ollama's /api/ps):
+  # inferenceProvider:
+  #   type: ollama
+  #   config:
+  #     endpoint: "http://localhost:11434/metrics"
+  #     api_base: "http://localhost:11434"
   # generic-prometheus example (works with TGI, SGLang, Ollama, Triton, any custom server):
   # inferenceProvider:
   #   type: generic-prometheus

--- a/internal/provider/inference/ollama/ollama.go
+++ b/internal/provider/inference/ollama/ollama.go
@@ -1,0 +1,166 @@
+// Package ollama provides an InferenceMetricsProvider for Ollama servers.
+//
+// Token and request metrics are read from Ollama's Prometheus /metrics endpoint
+// (available on Ollama builds that expose Prometheus metrics, or via a metrics
+// exporter sidecar). The currently-served model name is read from Ollama's
+// native /api/ps endpoint, which is available on all Ollama builds and is what
+// distinguishes this adapter from the generic-prometheus provider.
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aitra-ai/aitra-meter/internal/provider"
+)
+
+const (
+	defaultMetricsEndpoint = "http://localhost:11434/metrics"
+	defaultAPIBase         = "http://localhost:11434"
+	defaultOutputMetric    = "ollama_completion_tokens_total"
+	defaultRunningMetric   = "ollama_requests_active"
+)
+
+func init() {
+	provider.RegisterInference("ollama", func(config map[string]string) (provider.InferenceMetricsProvider, error) {
+		return build(config)
+	})
+}
+
+// build constructs an OllamaProvider from a config map, applying defaults for
+// any unset keys. Returns the concrete type so tests can inspect it.
+func build(config map[string]string) (*OllamaProvider, error) {
+	endpoint := config["endpoint"]
+	if endpoint == "" {
+		endpoint = defaultMetricsEndpoint
+	}
+	apiBase := config["api_base"]
+	if apiBase == "" {
+		apiBase = defaultAPIBase
+	}
+	outputMetric := config["output_tokens_metric"]
+	if outputMetric == "" {
+		outputMetric = defaultOutputMetric
+	}
+	runningMetric := config["requests_running_metric"]
+	if runningMetric == "" {
+		runningMetric = defaultRunningMetric
+	}
+	return &OllamaProvider{
+		endpoint:      endpoint,
+		apiBase:       strings.TrimRight(apiBase, "/"),
+		outputMetric:  outputMetric,
+		runningMetric: runningMetric,
+		client:        &http.Client{Timeout: 10 * time.Second},
+	}, nil
+}
+
+// OllamaProvider implements provider.InferenceMetricsProvider for Ollama.
+type OllamaProvider struct {
+	endpoint      string
+	apiBase       string
+	outputMetric  string
+	runningMetric string
+	client        *http.Client
+}
+
+func (o *OllamaProvider) Name() string { return "ollama" }
+
+// OutputTokens returns the cumulative completion-token counter from Ollama's
+// Prometheus /metrics endpoint.
+func (o *OllamaProvider) OutputTokens(ctx context.Context) (uint64, error) {
+	m, err := o.scrape(ctx)
+	if err != nil {
+		return 0, err
+	}
+	val, ok := m[o.outputMetric]
+	if !ok {
+		return 0, fmt.Errorf("metric %q not found at %s", o.outputMetric, o.endpoint)
+	}
+	return uint64(val), nil
+}
+
+// RequestsRunning returns the number of in-flight requests. A missing gauge is
+// treated as zero (idle), matching the vLLM adapter's behaviour.
+func (o *OllamaProvider) RequestsRunning(ctx context.Context) (int, error) {
+	m, err := o.scrape(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return int(m[o.runningMetric]), nil
+}
+
+// ModelName reports the currently-loaded model via Ollama's native /api/ps,
+// which works on every Ollama build regardless of Prometheus support. Returns
+// "unknown" when no model is resident.
+func (o *OllamaProvider) ModelName(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, o.apiBase+"/api/ps", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("querying %s/api/ps: %w", o.apiBase, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var ps struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(body, &ps); err != nil {
+		return "", fmt.Errorf("decoding %s/api/ps: %w", o.apiBase, err)
+	}
+	if len(ps.Models) == 0 {
+		return "unknown", nil
+	}
+	return ps.Models[0].Name, nil
+}
+
+// scrape parses the Prometheus text exposition at the metrics endpoint into a
+// metric-name -> value map. Samples with labels are keyed by their bare metric
+// name; the last matching series wins, which is sufficient for single-model
+// Ollama deployments.
+func (o *OllamaProvider) scrape(ctx context.Context) (map[string]float64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, o.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scraping %s: %w", o.endpoint, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	res := map[string]float64{}
+	for _, line := range strings.Split(string(body), "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		name := parts[0]
+		if i := strings.Index(name, "{"); i > 0 {
+			name = name[:i]
+		}
+		if val, err := strconv.ParseFloat(parts[len(parts)-1], 64); err == nil {
+			res[name] = val
+		}
+	}
+	return res, nil
+}

--- a/internal/provider/inference/ollama/ollama_test.go
+++ b/internal/provider/inference/ollama/ollama_test.go
@@ -1,0 +1,152 @@
+package ollama
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// sampleMetrics is a representative Ollama /metrics payload.
+const sampleMetrics = `# HELP ollama_completion_tokens_total Total completion tokens generated.
+# TYPE ollama_completion_tokens_total counter
+ollama_completion_tokens_total{model="qwen2.5-coder:32b"} 84213
+# HELP ollama_requests_active Number of in-flight requests.
+# TYPE ollama_requests_active gauge
+ollama_requests_active 2
+`
+
+// newProvider wires an OllamaProvider to a test server whose handler serves
+// the given /metrics body and /api/ps JSON.
+func newProvider(metricsBody, psBody string) (*httptest.Server, *OllamaProvider) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, metricsBody)
+	})
+	mux.HandleFunc("/api/ps", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, psBody)
+	})
+	ts := httptest.NewServer(mux)
+	p := &OllamaProvider{
+		endpoint:      ts.URL + "/metrics",
+		apiBase:       ts.URL,
+		outputMetric:  defaultOutputMetric,
+		runningMetric: defaultRunningMetric,
+		client:        ts.Client(),
+	}
+	return ts, p
+}
+
+func TestName(t *testing.T) {
+	p := &OllamaProvider{}
+	if p.Name() != "ollama" {
+		t.Errorf("got %q, want \"ollama\"", p.Name())
+	}
+}
+
+func TestOutputTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    uint64
+		wantErr bool
+	}{
+		{name: "reads counter value", body: sampleMetrics, want: 84213},
+		{name: "large counter", body: "ollama_completion_tokens_total{model=\"llama\"} 9999999\n", want: 9999999},
+		{name: "zero value", body: "ollama_completion_tokens_total 0\n", want: 0},
+		{name: "metric absent returns error", body: "# TYPE other gauge\nother 1\n", wantErr: true},
+		{name: "empty body returns error", body: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, p := newProvider(tc.body, `{"models":[]}`)
+			defer ts.Close()
+			got, err := p.OutputTokens(context.Background())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value %d)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRequestsRunning(t *testing.T) {
+	ts, p := newProvider(sampleMetrics, `{"models":[]}`)
+	defer ts.Close()
+	got, err := p.RequestsRunning(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("got %d, want 2", got)
+	}
+
+	// Missing gauge is treated as idle (0), not an error.
+	ts2, p2 := newProvider("ollama_completion_tokens_total 1\n", `{"models":[]}`)
+	defer ts2.Close()
+	got, err = p2.RequestsRunning(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("missing gauge: got %d, want 0", got)
+	}
+}
+
+func TestModelName(t *testing.T) {
+	tests := []struct {
+		name   string
+		psBody string
+		want   string
+	}{
+		{name: "loaded model", psBody: `{"models":[{"name":"qwen2.5-coder:32b"}]}`, want: "qwen2.5-coder:32b"},
+		{name: "no model loaded", psBody: `{"models":[]}`, want: "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, p := newProvider(sampleMetrics, tc.psBody)
+			defer ts.Close()
+			got, err := p.ModelName(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFactoryDefaults(t *testing.T) {
+	p, err := build(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.endpoint != defaultMetricsEndpoint {
+		t.Errorf("endpoint: got %q, want %q", p.endpoint, defaultMetricsEndpoint)
+	}
+	if p.outputMetric != defaultOutputMetric {
+		t.Errorf("outputMetric: got %q, want %q", p.outputMetric, defaultOutputMetric)
+	}
+
+	// Overrides and api_base trailing-slash trimming.
+	p, err = build(map[string]string{"api_base": "http://ollama:11434/", "output_tokens_metric": "custom_tokens"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.apiBase != "http://ollama:11434" {
+		t.Errorf("api_base trim: got %q, want %q", p.apiBase, "http://ollama:11434")
+	}
+	if p.outputMetric != "custom_tokens" {
+		t.Errorf("outputMetric override: got %q, want %q", p.outputMetric, "custom_tokens")
+	}
+}


### PR DESCRIPTION
## What

Adds a built-in `ollama` `InferenceMetricsProvider`, so Aitra Meter can meter Ollama inference servers as a first-class provider (previously only reachable via `generic-prometheus`).

## How it works

- **Token & request counters** are scraped from Ollama's Prometheus `/metrics` endpoint (`ollama_completion_tokens_total`, `ollama_requests_active` — both overridable via `config`).
- **Model name** is resolved from Ollama's native `/api/ps` endpoint, which is available on *every* Ollama build regardless of Prometheus support. This is the adapter's value-add over `generic-prometheus` (no `model_name_label` wrangling).

## Config

```yaml
measurementAgent:
  inferenceProvider:
    type: ollama
    config:
      endpoint: "http://localhost:11434/metrics"   # default
      api_base: "http://localhost:11434"            # default (used for /api/ps)
```

## Changes

- `internal/provider/inference/ollama/` — provider + table-driven tests (Name, OutputTokens, RequestsRunning, ModelName, factory defaults/overrides)
- Registered via blank import in `cmd/measurement-agent`; `-inference-provider` help updated
- `docs/reference/compatibility.md` — Ollama promoted from "community" to a built-in adapter, with a dedicated-provider section
- `helm/aitra-meter/values.yaml` — Ollama `inferenceProvider` example

## Notes

- Token metrics require an Ollama build (or exporter sidecar) that exposes a Prometheus `/metrics` endpoint; releases without `/metrics` will error on `OutputTokens` while model-name resolution via `/api/ps` still works. This is documented in the compatibility notes.
- `gofmt`/`go vet` clean; `go test ./internal/provider/...` passes; both binaries build.