### PR TITLE
fix(metrics): emit aitra_cluster_j_per_token — gauge was declared but never set

### DIFF
--- a/internal/aggregation/clusterjpt.go
+++ b/internal/aggregation/clusterjpt.go
@@ -1,0 +1,59 @@
+package aggregation
+
+import "time"
+
+// DefaultClusterWindow bounds how far back serving windows contribute to the
+// cluster-wide J/token aggregate. Long enough to smooth per-model report
+// jitter, short enough that the gauge tracks load changes within a minute.
+const DefaultClusterWindow = 60 * time.Second
+
+type clusterSample struct {
+	at     time.Time
+	joules float64
+	tokens float64
+}
+
+// clusterJPTTracker derives the cluster-wide J/token as Σenergy ÷ Σtokens
+// over the serving windows retained in its time span (issue: the
+// aitra_cluster_j_per_token gauge was declared but never set). Summing before
+// dividing weights each window by its token count; averaging per-window
+// ratios would not (see TestLoopClusterJPerTokenIsSumOfEnergyDividedBySumOfTokens).
+//
+// Not safe for concurrent use; callers hold the Loop mutex.
+type clusterJPTTracker struct {
+	window  time.Duration
+	samples []clusterSample // arrival order; evicted from the front
+	joules  float64
+	tokens  float64
+}
+
+func newClusterJPTTracker(window time.Duration) *clusterJPTTracker {
+	if window <= 0 {
+		window = DefaultClusterWindow
+	}
+	return &clusterJPTTracker{window: window}
+}
+
+// add records one serving window and returns Σenergy ÷ Σtokens over the
+// retained span, or 0 when no tokens are retained.
+func (c *clusterJPTTracker) add(now time.Time, joules, tokens float64) float64 {
+	c.samples = append(c.samples, clusterSample{at: now, joules: joules, tokens: tokens})
+	c.joules += joules
+	c.tokens += tokens
+
+	cutoff := now.Add(-c.window)
+	evict := 0
+	for evict < len(c.samples) && c.samples[evict].at.Before(cutoff) {
+		c.joules -= c.samples[evict].joules
+		c.tokens -= c.samples[evict].tokens
+		evict++
+	}
+	if evict > 0 {
+		c.samples = append(c.samples[:0], c.samples[evict:]...)
+	}
+
+	if c.tokens <= 0 {
+		return 0
+	}
+	return c.joules / c.tokens
+}

--- a/internal/aggregation/clusterjpt_test.go
+++ b/internal/aggregation/clusterjpt_test.go
@@ -1,0 +1,37 @@
+package aggregation
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClusterJPTTrackerSumsBeforeDividing(t *testing.T) {
+	tr := newClusterJPTTracker(time.Minute)
+	now := time.Unix(1000, 0)
+
+	if got := tr.add(now, 100, 200); got != 0.5 {
+		t.Errorf("first window: got %f, want 0.5", got)
+	}
+	// Σ = 300 J / 300 tokens = 1.0 — not the 1.25 an average of per-window
+	// ratios (0.5 and 2.0) would give.
+	if got := tr.add(now.Add(time.Second), 200, 100); got != 1.0 {
+		t.Errorf("second window: got %f, want Σenergy/Σtokens = 1.0", got)
+	}
+}
+
+func TestClusterJPTTrackerEvictsExpiredSamples(t *testing.T) {
+	tr := newClusterJPTTracker(time.Minute)
+	now := time.Unix(1000, 0)
+
+	tr.add(now, 1000, 10) // JPT 100 — should age out
+	if got := tr.add(now.Add(2*time.Minute), 100, 100); got != 1.0 {
+		t.Errorf("after eviction: got %f, want 1.0 from the surviving window only", got)
+	}
+}
+
+func TestClusterJPTTrackerZeroTokens(t *testing.T) {
+	tr := newClusterJPTTracker(time.Minute)
+	if got := tr.add(time.Unix(1000, 0), 50, 0); got != 0 {
+		t.Errorf("zero retained tokens: got %f, want 0", got)
+	}
+}

--- a/internal/aggregation/loop.go
+++ b/internal/aggregation/loop.go
@@ -42,8 +42,9 @@ type Loop struct {
 	site SiteParams
 
 	mu            sync.Mutex
-	cvByKey       map[string]*CVTracker      // key: node+"\x00"+modelName
-	servingByNode map[string]*servingTracker // key: node
+	cvByKey       map[string]*CVTracker         // key: node+"\x00"+modelName
+	servingByNode map[string]*servingTracker    // key: node
+	clusterByTier map[string]*clusterJPTTracker // key: calibration tier
 
 	// OTLPExporter is optional. When non-nil, each window is also emitted
 	// via OTLP to an OpenTelemetry Collector.
@@ -68,6 +69,7 @@ func NewLoop(
 		site:          site,
 		cvByKey:       make(map[string]*CVTracker),
 		servingByNode: make(map[string]*servingTracker),
+		clusterByTier: make(map[string]*clusterJPTTracker),
 	}
 }
 
@@ -174,7 +176,20 @@ func (l *Loop) ReportWindow(
 	cv.Add(jpt)
 	cvVal := cv.CV()
 	stable := cv.Stable()
+
+	// Cluster-wide J/token: Σenergy ÷ Σtokens over the recent span, per
+	// calibration tier (the gauge's label). Summing before dividing weights
+	// each window by its token count.
+	tierKey := string(cal.Tier)
+	ct, ok := l.clusterByTier[tierKey]
+	if !ok {
+		ct = newClusterJPTTracker(DefaultClusterWindow)
+		l.clusterByTier[tierKey] = ct
+	}
+	clusterJPT := ct.add(time.Now(), w.EnergyJoules, float64(w.OutputTokens))
 	l.mu.Unlock()
+
+	metrics.ClusterJPerToken.WithLabelValues(l.cluster, tierKey).Set(clusterJPT)
 
 	// --- Prometheus metrics ------------------------------------------------
 	method := string(attr.Method)

--- a/internal/aggregation/loop_test.go
+++ b/internal/aggregation/loop_test.go
@@ -597,6 +597,14 @@ func TestLoopClusterJPerTokenIsSumOfEnergyDividedBySumOfTokens(t *testing.T) {
 	if math.Abs(wantCluster-avgOfRatios) < 1e-9 {
 		t.Fatal("test setup error: Σenergy/Σtokens and avg-of-ratios must differ")
 	}
+
+	// The aitra_cluster_j_per_token gauge must carry the same aggregate.
+	gauge := testutil.ToFloat64(metrics.ClusterJPerToken.WithLabelValues(
+		"test-cluster", string(TierUncalibrated),
+	))
+	if math.Abs(gauge-wantCluster) > 1e-9 {
+		t.Errorf("aitra_cluster_j_per_token = %f, want %f", gauge, wantCluster)
+	}
 }
 
 // Every storage record must have attribution_method set to a known


### PR DESCRIPTION
## Problem

The Grafana **Demo A** panel "Cluster J/token" reads `aitra_cluster_j_per_token`, and the metric is documented in the README metric table, `docs/reference/metrics.md`, and the v1.0 spec — but no code path ever called `Set()` on the gauge. The panel has shown **No data** since the dashboard was provisioned.

## Fix

Derive the gauge in the aggregation loop as **Σenergy ÷ Σtokens** over a 60-second sliding span of serving windows, grouped by calibration tier (the gauge's label). Summing before dividing weights each window by its token count — the exact property the existing `TestLoopClusterJPerTokenIsSumOfEnergyDividedBySumOfTokens` documents (that test validated the formula against storage records but never touched the gauge; it now asserts the gauge too).

- `internal/aggregation/clusterjpt.go` — new sliding-window tracker (same style as `servingTracker`), evicts samples older than 60s, protected by the existing Loop mutex
- `internal/aggregation/loop.go` — update tracker and set the gauge on every accepted serving window
- `clusterjpt_test.go` — Σ/Σ vs avg-of-ratios, time-based eviction, zero-token guard

## Verification

Deployed to the demo cluster (lab24/25): `aitra_cluster_j_per_token{cluster="dev",calibration_tier="uncalibrated"}` now returns live values and the Demo A panel renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)