### PR TITLE
fix(aggregation): zero the idle gauge when residual power drops to zero

### DIFF
--- a/internal/aggregation/loop.go
+++ b/internal/aggregation/loop.go
@@ -92,6 +92,13 @@ func (l *Loop) ReportWindow(
 			// Per-model agents split power across series; drop the whole-node
 			// series so per-node sums aren't double counted.
 			metrics.GPUPowerWatts.DeleteLabelValues(w.Node, "all")
+		} else {
+			// Residual fell to zero — every GPU is allocated to a model. A
+			// frozen stale idle reading would double-count against the
+			// per-model series (seen live: a 174 W ghost after a model was
+			// scaled back up), so zero it explicitly.
+			metrics.IdlePowerWatts.WithLabelValues(w.Node).Set(0)
+			metrics.GPUPowerWatts.DeleteLabelValues(w.Node, "idle")
 		}
 		return &measurementv1.WindowAck{Accepted: false}, nil
 	}


### PR DESCRIPTION
When every GPU on a node is allocated to a model pod, the per-model agent's residual report carries zero power — but the residual branch only wrote the idle gauges on `PowerWatts > 0`, so the last non-zero idle reading froze and kept counting against the node forever.

Found live by an **energy-conservation audit** on the demo cluster: after a model was scaled down and back up, a 174 W idle ghost inflated the node's attributed power to 1898 W against **1559 W of ground truth** (DCGM energy counters differenced over the same 2-minute interval; instantaneous power snapshots proved too noisy to audit against under bursty load — two counter-differencing windows agreed within 0.5%).

Fix: on a zero-power residual, explicitly zero `aitra_idle_power_watts` and delete the node's `gpu_id="idle"` series.

Deployed to the demo cluster; the ghost series is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)